### PR TITLE
[Feat] 질문 등록 (사람) API 구현

### DIFF
--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -17,7 +17,13 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
-    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다.");
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+
+    // 책
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_404", "해당 책을 찾을 수 없습니다."),
+
+    // 멤버
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "해당 멤버를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/picky/domain/question/entity/Question.java
+++ b/src/main/java/com/picky/domain/question/entity/Question.java
@@ -6,7 +6,6 @@ import com.picky.domain.member.entity.Member;
 import com.picky.domain.question.entity.enums.QuestionType;
 import com.picky.domain.questionLike.entity.QuestionLike;
 import com.picky.global.entity.BaseEntity;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -40,14 +39,14 @@ public class Question extends BaseEntity {
   @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_question_member"))
   private Member member;
 
-  @Schema(description = "내용", example = "민음사")
+  @Column(nullable = false)
+  private String title;
+
   @Column(nullable = false, length = 512)
   private String content;
 
-  @Schema(description = "페이지 수", example = "46")
   private Integer pageNum;
 
-  @Schema(description = "AI 생성 여부", example = "false")
   @Builder.Default
   private Boolean isAiGenerated = false;
 

--- a/src/main/java/com/picky/domain/question/service/QuestionService.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionService.java
@@ -1,5 +1,15 @@
 package com.picky.domain.question.service;
 
+import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+
 public interface QuestionService {
 
+    /**
+     * 책에 대한 질문을 생성합니다.
+     *
+     * @param bookId 책 ID
+     * @return 생성된 질문의 응답 DTO
+     */
+    QuestionPostResponseDTO createQuestion(Long bookId, Long memberId, QuestionPostRequestDTO request);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -1,5 +1,15 @@
 package com.picky.domain.question.service;
 
+import com.picky.apiPayload.code.status.ErrorStatus;
+import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.book.entity.Book;
+import com.picky.domain.book.repository.BookRepository;
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.member.repository.MemberRepository;
+import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.repository.QuestionRepository;
+import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,4 +19,38 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class QuestionServiceImpl implements QuestionService {
 
+    private final QuestionRepository questionRepository;
+    private final BookRepository bookRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public QuestionPostResponseDTO createQuestion(Long bookId, Long memberId, QuestionPostRequestDTO request) {
+
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Question question = Question.builder()
+                .book(book)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .pageNum(request.getPage())
+                .isAiGenerated(false)
+                .member(member)
+                .build();
+
+        Question savedQuestion = questionRepository.save(question);
+
+        return QuestionPostResponseDTO.builder()
+                .id(savedQuestion.getId())
+                .title(savedQuestion.getTitle())
+                .content(savedQuestion.getContent())
+                .page(savedQuestion.getPageNum())
+                .isAI(savedQuestion.getIsAiGenerated())
+                .createdAt(savedQuestion.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
+++ b/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
@@ -1,16 +1,32 @@
 package com.picky.domain.question.web.controller;
 
+import com.picky.apiPayload.ApiResponse;
+import com.picky.domain.question.service.QuestionService;
+import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/question")
+@RequestMapping("/api")
 @Tag(name = "질문")
-@Slf4j
 public class QuestionController {
 
+    private final QuestionService questionService;
+
+    @Operation(summary = "질문 등록 API", description = "사람이 질문을 등록합니다.")
+    @PostMapping("/books/{bookId}/{memberId}/questions")
+    public ApiResponse<QuestionPostResponseDTO> createQuestion(@PathVariable Long bookId,
+                                                               @PathVariable Long memberId,
+                                                               @Valid @RequestBody QuestionPostRequestDTO request) {
+        return ApiResponse.onSuccess(questionService.createQuestion(bookId, memberId, request));
+    }
 }

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionRequestDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionRequestDTO.java
@@ -1,5 +1,28 @@
 package com.picky.domain.question.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class QuestionRequestDTO {
 
+    @Getter
+    @NoArgsConstructor
+    public static class QuestionPostRequestDTO {
+
+        @NotBlank(message = "제목은 필수입니다.")
+        @Schema(description = "제목", example = "질문제목")
+        private String title;
+
+        @NotBlank(message = "내용은 필수입니다.")
+        @Schema(description = "내용", example = "민음사")
+        private String content;
+
+        @Schema(description = "관련 페이지", example = "46")
+        private Integer page;
+
+        @Schema(description = "AI 생성 여부", example = "false")
+        private Boolean isAI;
+    }
 }

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -1,5 +1,29 @@
 package com.picky.domain.question.web.dto;
 
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class QuestionResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionPostResponseDTO {
+        private Long id;
+
+        private String title;
+
+        private String content;
+
+        private Integer page;
+
+        private Boolean isAI;
+
+        private LocalDateTime createdAt;
+    }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #22

## 📝작업 내용

- 질문 등록 (사람) API 구현했습니다
- 아직 멤버 로직이 없어서 임시로 memberId를 경로에 받으려고 합니다 -> 이건 멤버 구현되고 나면 지울게요
- 서비스단 좀 지저분해지면 컨버터 쓸까 생각중..