### PR TITLE
feat: 사용자 질문 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -1,12 +1,41 @@
 package com.picky.domain.question.repository;
 
 import com.picky.domain.question.entity.Question;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long>,
-    QuerydslPredicateExecutor<Question> {
+        QuerydslPredicateExecutor<Question> {
 
+    /**
+     * 특정 사용자가 작성한 질문 목록을 조회합니다. (기본 질문 정보와 책 정보만 조회)
+     */
+    @Query("SELECT DISTINCT q FROM Question q " +
+            "LEFT JOIN FETCH q.book b " +
+            "WHERE q.member.id = :memberId " +
+            "ORDER BY q.createdAt DESC")
+    List<Question> findByMemberIdWithBook(@Param("memberId") Long memberId);
+
+    /**
+     * 특정 질문들의 좋아요 수를 조회합니다.
+     */
+    @Query("SELECT q.id, COUNT(ql) FROM Question q " +
+            "LEFT JOIN q.questionLikes ql " +
+            "WHERE q.id IN :questionIds " +
+            "GROUP BY q.id")
+    List<Object[]> countLikesByQuestionIds(@Param("questionIds") List<Long> questionIds);
+
+    /**
+     * 특정 질문들의 답변 수를 조회합니다.
+     */
+    @Query("SELECT q.id, COUNT(a) FROM Question q " +
+            "LEFT JOIN q.answers a " +
+            "WHERE q.id IN :questionIds " +
+            "GROUP BY q.id")
+    List<Object[]> countAnswersByQuestionIds(@Param("questionIds") List<Long> questionIds);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionService.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionService.java
@@ -2,6 +2,7 @@ package com.picky.domain.question.service;
 
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
 
 public interface QuestionService {
 
@@ -12,4 +13,12 @@ public interface QuestionService {
      * @return 생성된 질문의 응답 DTO
      */
     QuestionPostResponseDTO createQuestion(Long bookId, Long memberId, QuestionPostRequestDTO request);
+
+    /**
+     * 특정 사용자가 작성한 질문 목록을 조회합니다.
+     *
+     * @param memberId 조회할 사용자 ID
+     * @return 사용자가 작성한 질문 목록
+     */
+    MyQuestionsResponseDTO getMyQuestions(Long memberId);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -10,6 +10,11 @@ import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionDTO;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,6 +56,69 @@ public class QuestionServiceImpl implements QuestionService {
                 .page(savedQuestion.getPageNum())
                 .isAI(savedQuestion.getIsAiGenerated())
                 .createdAt(savedQuestion.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    public MyQuestionsResponseDTO getMyQuestions(Long memberId) {
+        // 멤버 존재 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 해당 멤버가 작성한 질문들을 조회 (책 정보 포함)
+        List<Question> questions = questionRepository.findByMemberIdWithBook(memberId);
+
+        if (questions.isEmpty()) {
+            return MyQuestionsResponseDTO.builder()
+                    .questions(List.of())
+                    .build();
+        }
+
+        // 질문 ID 목록 추출
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .collect(Collectors.toList());
+
+        // 좋아요 수 조회
+        List<Object[]> likeCountResults = questionRepository.countLikesByQuestionIds(questionIds);
+        Map<Long, Long> likeCountMap = likeCountResults.stream()
+                .collect(Collectors.toMap(
+                        result -> (Long) result[0],
+                        result -> (Long) result[1]
+                ));
+
+        // 답변 수 조회
+        List<Object[]> answerCountResults = questionRepository.countAnswersByQuestionIds(questionIds);
+        Map<Long, Long> answerCountMap = answerCountResults.stream()
+                .collect(Collectors.toMap(
+                        result -> (Long) result[0],
+                        result -> (Long) result[1]
+                ));
+
+        // DTO로 변환
+        List<MyQuestionDTO> questionDTOs = questions.stream()
+                .map(question -> convertToMyQuestionDTO(question, likeCountMap, answerCountMap))
+                .collect(Collectors.toList());
+
+        return MyQuestionsResponseDTO.builder()
+                .questions(questionDTOs)
+                .build();
+    }
+
+    /**
+     * Question 엔티티를 MyQuestionDTO로 변환합니다.
+     */
+    private MyQuestionDTO convertToMyQuestionDTO(Question question,
+                                                 Map<Long, Long> likeCountMap,
+                                                 Map<Long, Long> answerCountMap) {
+        return MyQuestionDTO.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .author(question.getBook().getAuthor())
+                .book(question.getBook().getTitle())
+                .likes(Math.toIntExact(likeCountMap.getOrDefault(question.getId(), 0L)))
+                .comments(Math.toIntExact(answerCountMap.getOrDefault(question.getId(), 0L)))
+                .views(0)
                 .build();
     }
 }

--- a/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
+++ b/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
@@ -4,10 +4,13 @@ import com.picky.apiPayload.ApiResponse;
 import com.picky.domain.question.service.QuestionService;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,5 +31,13 @@ public class QuestionController {
                                                                @PathVariable Long memberId,
                                                                @Valid @RequestBody QuestionPostRequestDTO request) {
         return ApiResponse.onSuccess(questionService.createQuestion(bookId, memberId, request));
+    }
+
+    @Operation(summary = "사용자 질문 목록 조회 API", description = "특정 사용자가 작성한 모든 질문 목록을 조회합니다.")
+    @GetMapping("/members/{memberId}/questions")
+    public ApiResponse<MyQuestionsResponseDTO> getMyQuestions(
+            @Parameter(description = "조회할 사용자 ID", example = "1")
+            @PathVariable Long memberId) {
+        return ApiResponse.onSuccess(questionService.getMyQuestions(memberId));
     }
 }

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 public class QuestionResponseDTO {
 
@@ -26,4 +27,26 @@ public class QuestionResponseDTO {
         private LocalDateTime createdAt;
     }
 
+    // 사용자 질문 목록 조회
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MyQuestionDTO {
+        private Long id;
+        private String title;
+        private String author;
+        private String book;
+        private Integer likes;
+        private Integer comments;
+        private Integer views;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MyQuestionsResponseDTO {
+        private List<MyQuestionDTO> questions;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #30 

## 📝작업 내용

> 사용자 질문 목록 조회 API 구현

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 질문 목록 조회에 조회수가 필요한데 질문 엔티티 자체에 안 만들어져 있어서 일단은 빼고 만들었어요 나중에 수정할 예정