### PR TITLE
[Feat] 질문 조회 관련 API 구현

### DIFF
--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -26,7 +26,11 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "해당 멤버를 찾을 수 없습니다."),
 
     // 질문
-    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_404", "해당 질문을 찾을 수 없습니다.");
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_404", "해당 질문을 찾을 수 없습니다."),
+
+    // 질문 좋아요
+    ALREADY_LIKED(HttpStatus.BAD_REQUEST, "QUESTION_LIKE_401", "이미 좋아요를 눌렀습니다."),
+    QUESTION_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_LIKE_404", "해당 질문 좋아요를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,10 @@ public enum ErrorStatus implements BaseErrorCode {
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_404", "해당 책을 찾을 수 없습니다."),
 
     // 멤버
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "해당 멤버를 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "해당 멤버를 찾을 수 없습니다."),
+
+    // 질문
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_404", "해당 질문을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/picky/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/picky/domain/answer/repository/AnswerRepository.java
@@ -9,6 +9,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long>,
     QuerydslPredicateExecutor<Answer> {
-
-    int countByQuestion(Question question);
 }

--- a/src/main/java/com/picky/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/picky/domain/answer/repository/AnswerRepository.java
@@ -1,6 +1,7 @@
 package com.picky.domain.answer.repository;
 
 import com.picky.domain.answer.entity.Answer;
+import com.picky.domain.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
@@ -9,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface AnswerRepository extends JpaRepository<Answer, Long>,
     QuerydslPredicateExecutor<Answer> {
 
+    int countByQuestion(Question question);
 }

--- a/src/main/java/com/picky/domain/question/entity/Question.java
+++ b/src/main/java/com/picky/domain/question/entity/Question.java
@@ -47,6 +47,8 @@ public class Question extends BaseEntity {
 
   private Integer pageNum;
 
+  private Integer views;
+
   @Builder.Default
   private Boolean isAiGenerated = false;
 

--- a/src/main/java/com/picky/domain/question/entity/Question.java
+++ b/src/main/java/com/picky/domain/question/entity/Question.java
@@ -45,9 +45,9 @@ public class Question extends BaseEntity {
   @Column(nullable = false, length = 512)
   private String content;
 
-  private Integer pageNum;
+  private int pageNum;
 
-  private Integer views;
+  private int views;
 
   @Builder.Default
   private Boolean isAiGenerated = false;

--- a/src/main/java/com/picky/domain/question/entity/Question.java
+++ b/src/main/java/com/picky/domain/question/entity/Question.java
@@ -23,6 +23,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.BatchSize;
 
 @Getter
 @Entity
@@ -59,9 +60,11 @@ public class Question extends BaseEntity {
 
   @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
   @Builder.Default
+  @BatchSize(size = 100)
   private List<Answer> answers = new ArrayList<>();
 
   @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
   @Builder.Default
+  @BatchSize(size = 100)
   private List<QuestionLike> questionLikes = new ArrayList<>();
 }

--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -20,6 +20,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long>,
         WHERE q.id = :questionId
         """)
     Optional<Question> findWithBookById(@Param("questionId") Long questionId);
+
     /**
      * 특정 사용자가 작성한 질문 목록을 조회합니다. (기본 질문 정보와 책 정보만 조회)
      */
@@ -46,4 +47,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long>,
             "WHERE q.id IN :questionIds " +
             "GROUP BY q.id")
     List<Object[]> countAnswersByQuestionIds(@Param("questionIds") List<Long> questionIds);
+
+    List<Question> findByBookId(Long bookId);
 }

--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -14,13 +14,13 @@ import org.springframework.stereotype.Repository;
 public interface QuestionRepository extends JpaRepository<Question, Long>,
         QuerydslPredicateExecutor<Question> {
 
-    @Query("""
-        SELECT q
-        FROM Question q
-        JOIN FETCH q.book b
-        WHERE q.id = :questionId
-        """)
-    Optional<Question> findWithBookById(@Param("questionId") Long questionId);
+    // getQuestionDetail을 위한 쿼리
+    @Query("SELECT q FROM Question q JOIN FETCH q.book b JOIN FETCH q.member m WHERE q.id = :questionId")
+    Optional<Question> findByIdWithBookAndMember(@Param("questionId") Long questionId);
+
+    // getQuestionList를 위한 쿼리
+    @Query("SELECT q FROM Question q JOIN FETCH q.book b WHERE q.book.id = :bookId")
+    List<Question> findByBookIdWithBook(@Param("bookId") Long bookId);
 
     /**
      * 특정 사용자가 작성한 질문 목록을 조회합니다. (기본 질문 정보와 책 정보만 조회)
@@ -48,8 +48,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long>,
             "WHERE q.id IN :questionIds " +
             "GROUP BY q.id")
     List<Object[]> countAnswersByQuestionIds(@Param("questionIds") List<Long> questionIds);
-
-    List<Question> findByBookId(Long bookId);
 
     @Modifying(clearAutomatically = true)
     @Query("update Question q set q.views = q.views + 1 where q.id = :id")

--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -1,12 +1,22 @@
 package com.picky.domain.question.repository;
 
 import com.picky.domain.question.entity.Question;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long>,
     QuerydslPredicateExecutor<Question> {
 
+    @Query("""
+        SELECT q
+        FROM Question q
+        JOIN FETCH q.book b
+        WHERE q.id = :questionId
+        """)
+    Optional<Question> findWithBookById(@Param("questionId") Long questionId);
 }

--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -4,6 +4,7 @@ import com.picky.domain.question.entity.Question;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.repository.query.Param;
@@ -49,4 +50,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long>,
     List<Object[]> countAnswersByQuestionIds(@Param("questionIds") List<Long> questionIds);
 
     List<Question> findByBookId(Long bookId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Question q set q.views = q.views + 1 where q.id = :id")
+    int increaseViews(@Param("id") Long id);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionService.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionService.java
@@ -2,6 +2,7 @@ package com.picky.domain.question.service;
 
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionListResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
 
@@ -33,4 +34,11 @@ public interface QuestionService {
      * @return 사용자가 작성한 질문 목록
      */
     MyQuestionsResponseDTO getMyQuestions(Long memberId);
+
+    /**
+     * 도서별 질문 목록을 조회합니다.
+     * @param bookId
+     * @return 질문 목록 응답 DTO
+     */
+    QuestionListResponseDTO getQuestionList(Long bookId);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionService.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionService.java
@@ -1,6 +1,7 @@
 package com.picky.domain.question.service;
 
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 
 public interface QuestionService {
@@ -9,7 +10,18 @@ public interface QuestionService {
      * 책에 대한 질문을 생성합니다.
      *
      * @param bookId 책 ID
+     * @param memberId 질문을 작성하는 회원 ID
+     * @param request 질문 생성 요청 DTO
      * @return 생성된 질문의 응답 DTO
      */
     QuestionPostResponseDTO createQuestion(Long bookId, Long memberId, QuestionPostRequestDTO request);
+
+    /**
+     * 질문 상세 정보를 조회합니다.
+     *
+     * @param questionId 질문 ID
+     * @param memberId   요청하는 회원 ID (좋아요 여부 확인용)
+     * @return 질문 상세 응답 DTO
+     */
+    QuestionDetailResponseDTO getQuestionDetail(Long questionId, Long memberId);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -124,7 +124,7 @@ public class QuestionServiceImpl implements QuestionService {
                 .book(question.getBook().getTitle())
                 .likes(Math.toIntExact(likeCountMap.getOrDefault(question.getId(), 0L)))
                 .comments(Math.toIntExact(answerCountMap.getOrDefault(question.getId(), 0L)))
-                .views(0)
+                .views(question.getViews())
                 .build();
     }
 

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -11,6 +11,8 @@ import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionInfoResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionListResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import com.picky.domain.questionLike.repository.QuestionLikeRepository;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
@@ -153,5 +155,33 @@ public class QuestionServiceImpl implements QuestionService {
                         .build())
                 .isLiked(isLiked)
                 .build();
+    }
+
+    @Override
+    public QuestionListResponseDTO getQuestionList(Long bookId) {
+
+        bookRepository.findById(bookId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        List<Question> questions = questionRepository.findByBookId(bookId);
+
+        List<QuestionInfoResponseDTO> questionInfoResponseDTOs = questions.stream()
+                .map(q -> QuestionResponseDTO.QuestionInfoResponseDTO.builder()
+                    .id(q.getId())
+                    .title(q.getTitle())
+                    .content(q.getContent())
+                    .views(q.getViews())
+                    .answersCount(q.getAnswers().size())
+                    .isAI(q.getIsAiGenerated())
+                    .page(q.getPageNum())
+                    .createdAt(q.getCreatedAt())
+                    .build())
+            .collect(Collectors.toList());
+
+        return QuestionListResponseDTO.builder()
+            .questions(questionInfoResponseDTOs)
+            .totalCount(questionInfoResponseDTOs.size())
+            .hasMore(false) // TODO: 추후 페이징 한다면 처리
+            .build();
     }
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -129,7 +129,14 @@ public class QuestionServiceImpl implements QuestionService {
     }
 
     @Override
+    @Transactional // 조회수 증가 메서드 때문에 붙임
     public QuestionDetailResponseDTO getQuestionDetail(Long questionId, Long memberId) {
+
+        // 조회수 증가
+        int updatedViews = questionRepository.increaseViews(questionId);
+        if (updatedViews == 0) {
+            throw new GeneralException(ErrorStatus.QUESTION_NOT_FOUND);
+        }
 
         Question question = questionRepository.findWithBookById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -2,6 +2,7 @@ package com.picky.domain.question.service;
 
 import com.picky.apiPayload.code.status.ErrorStatus;
 import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.answer.repository.AnswerRepository;
 import com.picky.domain.book.entity.Book;
 import com.picky.domain.book.repository.BookRepository;
 import com.picky.domain.member.entity.Member;
@@ -33,6 +34,7 @@ public class QuestionServiceImpl implements QuestionService {
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
     private final QuestionLikeRepository questionLikeRepository;
+    private final AnswerRepository answerRepository;
 
     @Override
     @Transactional
@@ -154,8 +156,8 @@ public class QuestionServiceImpl implements QuestionService {
                 .author(question.getMember().getNickname())
                 .isAI(question.getIsAiGenerated())
                 .views(question.getViews())
-                .likes(question.getQuestionLikes().size())
-                .answersCount(question.getAnswers().size())
+                .likes(questionLikeRepository.countByQuestion(question))
+                .answersCount(answerRepository.countByQuestion(question))
                 .page(question.getPageNum())
                 .createdAt(question.getCreatedAt())
                 .book(QuestionResponseDTO.BookInfoResponseDTO.builder()
@@ -181,7 +183,8 @@ public class QuestionServiceImpl implements QuestionService {
                     .title(q.getTitle())
                     .content(q.getContent())
                     .views(q.getViews())
-                    .answersCount(q.getAnswers().size())
+                    .likes(questionLikeRepository.countByQuestion(q))
+                    .answersCount(answerRepository.countByQuestion(q))
                     .isAI(q.getIsAiGenerated())
                     .page(q.getPageNum())
                     .createdAt(q.getCreatedAt())

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -9,7 +9,10 @@ import com.picky.domain.member.repository.MemberRepository;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import com.picky.domain.questionLike.repository.QuestionLikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +25,7 @@ public class QuestionServiceImpl implements QuestionService {
     private final QuestionRepository questionRepository;
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
+    private final QuestionLikeRepository questionLikeRepository;
 
     @Override
     @Transactional
@@ -51,6 +55,35 @@ public class QuestionServiceImpl implements QuestionService {
                 .page(savedQuestion.getPageNum())
                 .isAI(savedQuestion.getIsAiGenerated())
                 .createdAt(savedQuestion.getCreatedAt())
+                .build();
+    }
+
+    @Override
+    public QuestionDetailResponseDTO getQuestionDetail(Long questionId, Long memberId) {
+
+        Question question = questionRepository.findWithBookById(questionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        // 좋아요 여부 확인
+        Boolean isLiked = questionLikeRepository.existsByMemberIdAndQuestionId(memberId, questionId);
+
+        return QuestionDetailResponseDTO.builder()
+                .id(question.getId())
+                .title(question.getTitle())
+                .content(question.getContent())
+                .author(question.getMember().getNickname())
+                .isAI(question.getIsAiGenerated())
+                .views(question.getViews())
+                .likes(question.getQuestionLikes().size())
+                .answersCount(question.getAnswers().size())
+                .page(question.getPageNum())
+                .createdAt(question.getCreatedAt())
+                .book(QuestionResponseDTO.BookInfoResponseDTO.builder()
+                        .id(question.getBook().getId())
+                        .title(question.getBook().getTitle())
+                        .author(question.getBook().getAuthor())
+                        .build())
+                .isLiked(isLiked)
                 .build();
     }
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -141,8 +141,11 @@ public class QuestionServiceImpl implements QuestionService {
         Question question = questionRepository.findWithBookById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
         // 좋아요 여부 확인
-        Boolean isLiked = questionLikeRepository.existsByMemberIdAndQuestionId(memberId, questionId);
+        Boolean isLiked = questionLikeRepository.existsByMemberAndQuestion(member, question);
 
         return QuestionDetailResponseDTO.builder()
                 .id(question.getId())

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -34,7 +34,6 @@ public class QuestionServiceImpl implements QuestionService {
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
     private final QuestionLikeRepository questionLikeRepository;
-    private final AnswerRepository answerRepository;
 
     @Override
     @Transactional
@@ -140,8 +139,8 @@ public class QuestionServiceImpl implements QuestionService {
             throw new GeneralException(ErrorStatus.QUESTION_NOT_FOUND);
         }
 
-        Question question = questionRepository.findWithBookById(questionId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+        Question question = questionRepository.findByIdWithBookAndMember(questionId)
+                                              .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -156,8 +155,8 @@ public class QuestionServiceImpl implements QuestionService {
                 .author(question.getMember().getNickname())
                 .isAI(question.getIsAiGenerated())
                 .views(question.getViews())
-                .likes(questionLikeRepository.countByQuestion(question))
-                .answersCount(answerRepository.countByQuestion(question))
+                .likes(question.getQuestionLikes().size())
+                .answersCount(question.getAnswers().size())
                 .page(question.getPageNum())
                 .createdAt(question.getCreatedAt())
                 .book(QuestionResponseDTO.BookInfoResponseDTO.builder()
@@ -175,7 +174,7 @@ public class QuestionServiceImpl implements QuestionService {
         bookRepository.findById(bookId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
 
-        List<Question> questions = questionRepository.findByBookId(bookId);
+        List<Question> questions = questionRepository.findByBookIdWithBook(bookId);
 
         List<QuestionInfoResponseDTO> questionInfoResponseDTOs = questions.stream()
                 .map(q -> QuestionResponseDTO.QuestionInfoResponseDTO.builder()
@@ -183,8 +182,8 @@ public class QuestionServiceImpl implements QuestionService {
                     .title(q.getTitle())
                     .content(q.getContent())
                     .views(q.getViews())
-                    .likes(questionLikeRepository.countByQuestion(q))
-                    .answersCount(answerRepository.countByQuestion(q))
+                    .likes(q.getQuestionLikes().size())
+                    .answersCount(q.getAnswers().size())
                     .isAI(q.getIsAiGenerated())
                     .page(q.getPageNum())
                     .createdAt(q.getCreatedAt())

--- a/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
+++ b/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
@@ -3,11 +3,14 @@ package com.picky.domain.question.web.controller;
 import com.picky.apiPayload.ApiResponse;
 import com.picky.domain.question.service.QuestionService;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionListResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,10 +26,23 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @Operation(summary = "질문 등록 API", description = "사람이 질문을 등록합니다.")
-    @PostMapping("/books/{bookId}/{memberId}/questions")
+    @PostMapping("/books/{bookId}/questions/{memberId}")
     public ApiResponse<QuestionPostResponseDTO> createQuestion(@PathVariable Long bookId,
                                                                @PathVariable Long memberId,
                                                                @Valid @RequestBody QuestionPostRequestDTO request) {
         return ApiResponse.onSuccess(questionService.createQuestion(bookId, memberId, request));
     }
+
+    @Operation(summary = "질문 상세 조회 API", description = "질문 상세 정보를 조회합니다.")
+    @GetMapping("/questions/{questionId}/{memberId}")
+    public ApiResponse<QuestionDetailResponseDTO> getQuestionDetail(@PathVariable Long questionId,
+                                                                    @PathVariable Long memberId) {
+        return ApiResponse.onSuccess(questionService.getQuestionDetail(questionId, memberId));
+    }
+
+//    @Operation(summary = "질문 목록 조회 API", description = "책에 대한 질문 목록을 조회합니다.")
+//    @GetMapping("/books/{bookId}/questions")
+//    public ApiResponse<QuestionListResponseDTO> getQuestionList(@PathVariable Long bookId) {
+//        return ApiResponse.onSuccess(questionService.getQuestionList(bookId));
+//    }
 }

--- a/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
+++ b/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
@@ -42,11 +42,11 @@ public class QuestionController {
         return ApiResponse.onSuccess(questionService.getQuestionDetail(questionId, memberId));
     }
 
-//    @Operation(summary = "질문 목록 조회 API", description = "책에 대한 질문 목록을 조회합니다.")
-//    @GetMapping("/books/{bookId}/questions")
-//    public ApiResponse<QuestionListResponseDTO> getQuestionList(@PathVariable Long bookId) {
-//        return ApiResponse.onSuccess(questionService.getQuestionList(bookId));
-//    }
+    @Operation(summary = "책에 대한 질문 목록 조회 API", description = "책에 대한 질문 목록을 조회합니다.")
+    @GetMapping("/books/{bookId}/questions")
+    public ApiResponse<QuestionListResponseDTO> getQuestionList(@PathVariable Long bookId) {
+        return ApiResponse.onSuccess(questionService.getQuestionList(bookId));
+    }
 
     @Operation(summary = "사용자 질문 목록 조회 API", description = "특정 사용자가 작성한 모든 질문 목록을 조회합니다.")
     @GetMapping("/members/{memberId}/questions")

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -1,6 +1,7 @@
 package com.picky.domain.question.web.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,17 +13,66 @@ public class QuestionResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class QuestionPostResponseDTO {
+    public static class QuestionPostResponseDTO { // 질문 등록 응답 DTO
         private Long id;
-
         private String title;
-
         private String content;
-
         private Integer page;
-
         private Boolean isAI;
+        private LocalDateTime createdAt;
+    }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionDetailResponseDTO { // 질문 상세 응답 DTO
+        private Long id;
+        private String title;
+        private String content;
+        private String author; // 멤버 (질문 작성자)
+        private Boolean isAI;
+        private Integer views;
+        private Integer likes;
+        private Integer answersCount;
+        private Integer page;
+        private LocalDateTime createdAt;
+        private BookInfoResponseDTO book; // 관련 책 정보
+        private Boolean isLiked; // 사용자가 좋아요를 눌렀는지 여부
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BookInfoResponseDTO {
+        private Long id;
+        private String title;
+        private String author;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionListResponseDTO { // 질문 목록 응답 DTO
+        private List<QuestionInfoResponseDTO> questions; // 질문 목록
+        private Integer totalCount; // 전체 질문 수
+        private boolean hasMore; // 추가 데이터 존재 여부
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionInfoResponseDTO {
+        private Long id;
+        private String title;
+        private String content;
+        private Integer views;
+        private Integer answersCount;
+        private Boolean isAI;
+        private Integer page;
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -70,6 +70,7 @@ public class QuestionResponseDTO {
         private String title;
         private String content;
         private int views;
+        private int likes; // 좋아요 수
         private int answersCount;
         private Boolean isAI;
         private int page;

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.util.List;
 
 public class QuestionResponseDTO {
 
@@ -18,7 +17,7 @@ public class QuestionResponseDTO {
         private Long id;
         private String title;
         private String content;
-        private Integer page;
+        private int page;
         private Boolean isAI;
         private LocalDateTime createdAt;
     }
@@ -33,10 +32,10 @@ public class QuestionResponseDTO {
         private String content;
         private String author; // 멤버 (질문 작성자)
         private Boolean isAI;
-        private Integer views;
-        private Integer likes;
-        private Integer answersCount;
-        private Integer page;
+        private int views;
+        private int likes;
+        private int answersCount;
+        private int page;
         private LocalDateTime createdAt;
         private BookInfoResponseDTO book; // 관련 책 정보
         private Boolean isLiked; // 사용자가 좋아요를 눌렀는지 여부
@@ -58,7 +57,7 @@ public class QuestionResponseDTO {
     @Builder
     public static class QuestionListResponseDTO { // 질문 목록 응답 DTO
         private List<QuestionInfoResponseDTO> questions; // 질문 목록
-        private Integer totalCount; // 전체 질문 수
+        private int totalCount; // 전체 질문 수
         private boolean hasMore; // 추가 데이터 존재 여부
     }
 
@@ -70,10 +69,10 @@ public class QuestionResponseDTO {
         private Long id;
         private String title;
         private String content;
-        private Integer views;
-        private Integer answersCount;
+        private int views;
+        private int answersCount;
         private Boolean isAI;
-        private Integer page;
+        private int page;
         private LocalDateTime createdAt;
     }
 
@@ -87,9 +86,9 @@ public class QuestionResponseDTO {
         private String title;
         private String author;
         private String book;
-        private Integer likes;
-        private Integer comments;
-        private Integer views;
+        private int likes;
+        private int comments;
+        private int views;
     }
 
     @Getter

--- a/src/main/java/com/picky/domain/questionLike/repository/QuestionLikeRepository.java
+++ b/src/main/java/com/picky/domain/questionLike/repository/QuestionLikeRepository.java
@@ -1,6 +1,9 @@
 package com.picky.domain.questionLike.repository;
 
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.question.entity.Question;
 import com.picky.domain.questionLike.entity.QuestionLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
@@ -9,6 +12,9 @@ import org.springframework.stereotype.Repository;
 public interface QuestionLikeRepository extends JpaRepository<QuestionLike, Long>,
     QuerydslPredicateExecutor<QuestionLike> {
 
-    Boolean existsByMemberIdAndQuestionId(Long questionId, Long memberId);
+    Boolean existsByMemberAndQuestion(Member member, Question question);
 
+    Optional<QuestionLike> findByMemberAndQuestion(Member member, Question question);
+
+    int countByQuestion(Question question);
 }

--- a/src/main/java/com/picky/domain/questionLike/repository/QuestionLikeRepository.java
+++ b/src/main/java/com/picky/domain/questionLike/repository/QuestionLikeRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface QuestionLikeRepository extends JpaRepository<QuestionLike, Long>,
     QuerydslPredicateExecutor<QuestionLike> {
 
+    Boolean existsByMemberIdAndQuestionId(Long questionId, Long memberId);
+
 }

--- a/src/main/java/com/picky/domain/questionLike/service/QuestionLikeService.java
+++ b/src/main/java/com/picky/domain/questionLike/service/QuestionLikeService.java
@@ -1,5 +1,14 @@
 package com.picky.domain.questionLike.service;
 
+import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.QuestionLikeStatusResponseDTO;
+
 public interface QuestionLikeService {
 
+    /**
+     * 특정 질문에 좋아요를 추가/삭제합니다.
+     * @param questionId 질문 ID
+     * @param memberId  회원 ID
+     * @return 질문 좋아요 상태 응답 DTO
+     */
+    QuestionLikeStatusResponseDTO likeQuestion(Long questionId, Long memberId);
 }

--- a/src/main/java/com/picky/domain/questionLike/service/QuestionLikeServiceImpl.java
+++ b/src/main/java/com/picky/domain/questionLike/service/QuestionLikeServiceImpl.java
@@ -1,12 +1,64 @@
 package com.picky.domain.questionLike.service;
 
+import com.picky.apiPayload.code.status.ErrorStatus;
+import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.member.repository.MemberRepository;
+import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.repository.QuestionRepository;
+import com.picky.domain.questionLike.entity.QuestionLike;
+import com.picky.domain.questionLike.repository.QuestionLikeRepository;
+import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.QuestionLikeStatusResponseDTO;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class QuestionLikeServiceImpl implements QuestionLikeService{
 
+    private final QuestionRepository questionRepository;
+    private final MemberRepository memberRepository;
+    private final QuestionLikeRepository questionLikeRepository;
+
+    @Override
+    public QuestionLikeStatusResponseDTO likeQuestion(Long questionId, Long memberId) {
+
+        Question question = questionRepository.findById(questionId)
+                                   .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberId)
+                                  .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+
+        Optional<QuestionLike> existingLike = questionLikeRepository.findByMemberAndQuestion(member, question);
+
+        if(existingLike.isPresent()) {
+            // 이미 좋아요 했으면 취소 처리
+            questionLikeRepository.delete(existingLike.get());
+
+            int likeCounts = questionLikeRepository.countByQuestion(question);
+
+            return QuestionLikeStatusResponseDTO.builder()
+                .isLiked(false)
+                .likeCounts(likeCounts)
+                .build();
+        } else {
+            // 좋아요 안했으면 추가 처리
+            QuestionLike questionLike = QuestionLike.builder()
+                                              .question(question)
+                                              .member(member)
+                                              .build();
+            questionLikeRepository.save(questionLike);
+
+            int likeCounts = questionLikeRepository.countByQuestion(question);
+
+            return QuestionLikeStatusResponseDTO.builder()
+                .isLiked(true)
+                .likeCounts(likeCounts)
+                .build();
+        }
+    }
 }

--- a/src/main/java/com/picky/domain/questionLike/web/controller/QuestionLikeController.java
+++ b/src/main/java/com/picky/domain/questionLike/web/controller/QuestionLikeController.java
@@ -1,15 +1,29 @@
 package com.picky.domain.questionLike.web.controller;
 
+import com.picky.apiPayload.ApiResponse;
+import com.picky.domain.questionLike.service.QuestionLikeService;
+import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.QuestionLikeStatusResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/question-like")
-@Tag(name = "질문 좋아요")
+@Tag(name = "질문 좋아요/취소")
 public class QuestionLikeController {
 
+    private final QuestionLikeService questionLikeService;
+
+    @Operation(summary = "질문 좋아요/취소", description = "특정 질문에 좋아요를 추가/취소합니다.")
+    @PostMapping("/{questionId}/{memberId}")
+    public ApiResponse<QuestionLikeStatusResponseDTO> likeQuestion(@PathVariable Long questionId, @PathVariable Long memberId) {
+        return ApiResponse.onSuccess(questionLikeService.likeQuestion(questionId, memberId));
+    }
 }

--- a/src/main/java/com/picky/domain/questionLike/web/dto/QuestionLikeResponseDTO.java
+++ b/src/main/java/com/picky/domain/questionLike/web/dto/QuestionLikeResponseDTO.java
@@ -1,5 +1,18 @@
 package com.picky.domain.questionLike.web.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class QuestionLikeResponseDTO {
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class QuestionLikeStatusResponseDTO { // 질문 좋아요/취소 상태 응답 DTO
+        private Boolean isLiked; // 좋아요 상태
+        private int likeCounts; // 해당 질문의 총 좋아요 수
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #24 

## 📝작업 내용

- 질문 상세 조회, 목록 조회, 질문 좋아요/취소 API 구현
- null일 이유가 없는 필드들은 wrapper 클래스에서 primitive 타입으로 변경
- Question 엔티티의 answers, questionLikes에 BatchSize 적용 (N+1 개선)