### PR TITLE
feat: 대댓글 기능 추가 및 정렬 기능 구현

### DIFF
--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -34,7 +34,11 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 질문 좋아요
     ALREADY_LIKED(HttpStatus.BAD_REQUEST, "QUESTION_LIKE_401", "이미 좋아요를 눌렀습니다."),
-    QUESTION_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_LIKE_404", "해당 질문 좋아요를 찾을 수 없습니다.");
+    QUESTION_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_LIKE_404", "해당 질문 좋아요를 찾을 수 없습니다."),
+
+    // 답변
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER_404", "해당 답변을 찾을 수 없습니다."),
+    INVALID_PARENT_ANSWER(HttpStatus.BAD_REQUEST, "ANSWER_400", "부모 답변이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/picky/domain/answer/entity/Answer.java
+++ b/src/main/java/com/picky/domain/answer/entity/Answer.java
@@ -4,12 +4,17 @@ import com.picky.domain.member.entity.Member;
 import com.picky.domain.question.entity.Question;
 import com.picky.global.entity.BaseEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,4 +43,13 @@ public class Answer extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_answer_member"))
   private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_answer_id", foreignKey = @ForeignKey(name = "fk_answer_parent_answer"))
+  private Answer parentAnswer;
+
+  @Builder.Default
+  @OneToMany(mappedBy = "parentAnswer", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OrderBy("createdAt ASC")
+  private List<Answer> childrenAnswers = new ArrayList<>();
 }

--- a/src/main/java/com/picky/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerService.java
@@ -31,5 +31,5 @@ public interface AnswerService {
      * @param questionId 조회할 질문 ID
      * @return 해당 질문에 대한 답변 목록 DTO
      */
-    AnswerListResponseDTO getAnswersByQuestion(Long questionId);
+    AnswerListResponseDTO getAnswersByQuestion(Long questionId, String sort);
 }

--- a/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
@@ -14,8 +14,12 @@ import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.repository.MemberRepository;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +36,7 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public MyAnswersResponseDTO getMyAnswers(Long memberId) {
         // 멤버 존재 확인
-        Member member = memberRepository.findById(memberId)
+        memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 해당 멤버가 작성한 답변들을 조회 (질문 및 책 정보 포함)
@@ -82,11 +86,22 @@ public class AnswerServiceImpl implements AnswerService {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
+        Answer parentAnswer = null;
+        if (request.getParentAnswerId() != null) { // 부모 댓글이 있다면 -> 대댓글을 작성하겠단 뜻!
+            parentAnswer = answerRepository.findById(request.getParentAnswerId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.ANSWER_NOT_FOUND));
+
+            if (parentAnswer.getParentAnswer() != null) {
+                throw new GeneralException(ErrorStatus.INVALID_PARENT_ANSWER);
+            }
+        }
+
         Answer answer = Answer.builder()
                 .content(request.getContent())
                 .isAiGenerated(request.getIsAI())
                 .member(member)
                 .question(question)
+                .parentAnswer(parentAnswer) // 부모 답변 설정
                 .build();
 
         Answer savedAnswer = answerRepository.save(answer);
@@ -101,28 +116,56 @@ public class AnswerServiceImpl implements AnswerService {
     }
 
     @Override
-    public AnswerListResponseDTO getAnswersByQuestion(Long questionId) {
+    public AnswerListResponseDTO getAnswersByQuestion(Long questionId, String sort) {
 
         questionRepository.findById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
-
         List<Answer> answers = answerRepository.findByQuestionIdWithMember(questionId);
 
-        List<AnswerInfoResponseDTO> responseDTOs = answers.stream()
-                .map(a -> AnswerInfoResponseDTO.builder()
-                        .id(a.getId())
-                        .content(a.getContent())
-                        .author(a.getMember().getName())
-                        .isAI(a.getIsAiGenerated())
-                        .createdAt(a.getCreatedAt())
-                        .build())
-                .collect(Collectors.toList());
+        Map<Long, List<AnswerInfoResponseDTO>> childrenMap = answers.stream()
+            .filter(a -> a.getParentAnswer() != null) // 이건 전부 대댓글
+            .collect(Collectors.groupingBy(
+                a -> a.getParentAnswer().getId(), // 부모 댓글 id 기준으로 묶기
+                Collectors.mapping(this::convertToAnswerInfoDTO, Collectors.toList())
+            ));
+
+        // 부모 댓글만 필터링
+        Stream<Answer> parentStream = answers.stream()
+                                             .filter(a -> a.getParentAnswer() == null);
+
+        if ("latest".equalsIgnoreCase(sort)) {
+            parentStream = parentStream.sorted(Comparator.comparing(Answer::getCreatedAt).reversed());
+        } else if ("oldest".equalsIgnoreCase(sort)) {
+            parentStream = parentStream.sorted(Comparator.comparing(Answer::getCreatedAt));
+        }
+
+        // DTO 변환
+        List<AnswerInfoResponseDTO> responseDTOs = parentStream
+            .map(parent -> AnswerInfoResponseDTO.builder()
+                                                .id(parent.getId())
+                                                .content(parent.getContent())
+                                                .author(parent.getMember().getName())
+                                                .isAI(parent.getIsAiGenerated())
+                                                .createdAt(parent.getCreatedAt())
+                                                .childrenAnswers(childrenMap.getOrDefault(parent.getId(), Collections.emptyList())) // 대댓글은 항상 오래된순
+                                                .build()
+            )
+            .collect(Collectors.toList());
 
         return AnswerListResponseDTO.builder()
                 .answers(responseDTOs)
-                .totalCount(responseDTOs.size())
-                .hasNext(false) // TODO: 추후 페이징 처리 시 변경
+                .build();
+    }
+
+    private AnswerInfoResponseDTO convertToAnswerInfoDTO(Answer answer) {
+        return AnswerInfoResponseDTO.builder()
+                .id(answer.getId())
+                .content(answer.getContent())
+                .author(answer.getMember().getName())
+                .isAI(answer.getIsAiGenerated())
+                .createdAt(answer.getCreatedAt())
+                .childrenAnswers(Collections.emptyList())
                 .build();
     }
 }

--- a/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
+++ b/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -46,7 +47,7 @@ public class AnswerController {
 
     @Operation(summary = "질문별 답변 조회 API", description = "특정 질문에 대한 모든 답변을 조회합니다.")
     @GetMapping("/questions/{questionId}/answers")
-    public ApiResponse<AnswerListResponseDTO> getAnswersByQuestion(@PathVariable Long questionId) {
-        return ApiResponse.onSuccess(answerService.getAnswersByQuestion(questionId));
+    public ApiResponse<AnswerListResponseDTO> getAnswersByQuestion(@PathVariable Long questionId, @Parameter(description = "정렬 기준 (latest: 최신순, oldest: 오래된 순)", required = false) @RequestParam(defaultValue = "oldest") String sort) {
+        return ApiResponse.onSuccess(answerService.getAnswersByQuestion(questionId, sort));
     }
 }

--- a/src/main/java/com/picky/domain/answer/web/dto/AnswerRequestDTO.java
+++ b/src/main/java/com/picky/domain/answer/web/dto/AnswerRequestDTO.java
@@ -10,5 +10,6 @@ public class AnswerRequestDTO {
     public static class AnswerCreateRequestDTO {
         private String content;
         private Boolean isAI;
+        private Long parentAnswerId; // 대댓글인 경우 부모 답변 ID
     }
 }

--- a/src/main/java/com/picky/domain/answer/web/dto/AnswerResponseDTO.java
+++ b/src/main/java/com/picky/domain/answer/web/dto/AnswerResponseDTO.java
@@ -1,5 +1,6 @@
 package com.picky.domain.answer.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,8 +49,6 @@ public class AnswerResponseDTO {
     @Builder
     public static class AnswerListResponseDTO { // 질문별 답변 목록 조회 응답
         private List<AnswerInfoResponseDTO> answers; // 답변 목록
-        private int totalCount; // 전체 답변 수
-        private boolean hasNext; // 다음 페이지 존재 여부
     }
 
     @Getter
@@ -62,5 +61,7 @@ public class AnswerResponseDTO {
         private String author; // 작성자 이름
         private Boolean isAI;
         private LocalDateTime createdAt;
+        @Schema(description = "대댓글 목록")
+        private List<AnswerInfoResponseDTO> childrenAnswers; // 대댓글 목록
     }
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -192,8 +192,6 @@ public class QuestionServiceImpl implements QuestionService {
 
         return QuestionListResponseDTO.builder()
             .questions(questionInfoResponseDTOs)
-            .totalCount(questionInfoResponseDTOs.size())
-            .hasMore(false) // TODO: 추후 페이징 한다면 처리
             .build();
     }
 }

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -57,8 +57,6 @@ public class QuestionResponseDTO {
     @Builder
     public static class QuestionListResponseDTO { // 질문 목록 응답 DTO
         private List<QuestionInfoResponseDTO> questions; // 질문 목록
-        private int totalCount; // 전체 질문 수
-        private boolean hasMore; // 추가 데이터 존재 여부
     }
 
     @Getter


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #52 

## 📝작업 내용

- 대댓글, 댓글 정렬 구현
- 정렬은 쿼리스트링으로 붙여주면 됩니다 (latest: 최신순, oldest: 오래된 순, default는 오래된 순)
- 대댓글은 댓글과 같은 API를 쓰되, parentAnswerId에 부모가 되는 댓글 id를 같이 전달해주면 그에 대한 대댓글을 생성합니다
- 대댓글이 아닌 그냥 댓글이라면 parentAnswerId를 null로 보내면 됩니다
- 그리고 대대댓글 같은 건 없게 막아놨어요