### PR TITLE
feat: 질문/댓글/대댓글 삭제 API 구현

### DIFF
--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -38,7 +38,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 답변
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER_404", "해당 답변을 찾을 수 없습니다."),
-    INVALID_PARENT_ANSWER(HttpStatus.BAD_REQUEST, "ANSWER_400", "부모 답변이 유효하지 않습니다.");
+    INVALID_PARENT_ANSWER(HttpStatus.BAD_REQUEST, "ANSWER_400", "부모 답변이 유효하지 않습니다."),
+    NOT_ANSWER_AUTHOR(HttpStatus.FORBIDDEN, "ANSWER_403", "답변 작성자만 삭제할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -31,6 +31,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 질문
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QUESTION_404", "해당 질문을 찾을 수 없습니다."),
+    NOT_QUESTION_AUTHOR(HttpStatus.FORBIDDEN, "QUESTION_403", "질문 작성자만 삭제할 수 있습니다."),
 
     // 질문 좋아요
     ALREADY_LIKED(HttpStatus.BAD_REQUEST, "QUESTION_LIKE_401", "이미 좋아요를 눌렀습니다."),

--- a/src/main/java/com/picky/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerService.java
@@ -32,4 +32,12 @@ public interface AnswerService {
      * @return 해당 질문에 대한 답변 목록 DTO
      */
     AnswerListResponseDTO getAnswersByQuestion(Long questionId, String sort);
+
+    /**
+     * 특정 답변을 삭제합니다.
+     *
+     * @param answerId 삭제할 답변 ID
+     * @param memberId 요청을 수행하는 사용자 ID
+     */
+    void deleteAnswer(Long answerId, Long memberId);
 }

--- a/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
@@ -168,4 +168,17 @@ public class AnswerServiceImpl implements AnswerService {
                 .childrenAnswers(Collections.emptyList())
                 .build();
     }
+
+    @Transactional
+    @Override
+    public void deleteAnswer(Long answerId, Long memberId) {
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ANSWER_NOT_FOUND));
+
+        if (!answer.getMember().getId().equals(memberId)) { // 자기가 작성한 댓글/대댓글만 삭제 가능
+            throw new GeneralException(ErrorStatus.NOT_ANSWER_AUTHOR);
+        }
+
+        answerRepository.delete(answer);
+    }
 }

--- a/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
+++ b/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,5 +50,15 @@ public class AnswerController {
     @GetMapping("/questions/{questionId}/answers")
     public ApiResponse<AnswerListResponseDTO> getAnswersByQuestion(@PathVariable Long questionId, @Parameter(description = "정렬 기준 (latest: 최신순, oldest: 오래된 순)", required = false) @RequestParam(defaultValue = "oldest") String sort) {
         return ApiResponse.onSuccess(answerService.getAnswersByQuestion(questionId, sort));
+    }
+
+    @Operation(summary = "답변 삭제 API", description = "특정 답변을 삭제합니다.")
+    @DeleteMapping("/answers/{answerId}/{memberId}")
+    public ApiResponse<String> deleteAnswer(
+        @PathVariable Long answerId,
+        @PathVariable Long memberId
+    ) {
+        answerService.deleteAnswer(answerId, memberId);
+        return ApiResponse.onSuccess("답변이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionService.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionService.java
@@ -41,4 +41,12 @@ public interface QuestionService {
      * @return 질문 목록 응답 DTO
      */
     QuestionListResponseDTO getQuestionList(Long bookId);
+
+    /**
+     * 질문을 삭제합니다.
+     *
+     * @param questionId 삭제할 질문 ID
+     * @param memberId   요청하는 회원 ID (작성자 확인용)
+     */
+    void deleteQuestion(Long questionId, Long memberId);
 }

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -194,4 +194,17 @@ public class QuestionServiceImpl implements QuestionService {
             .questions(questionInfoResponseDTOs)
             .build();
     }
+
+    @Transactional
+    @Override
+    public void deleteQuestion(Long questionId, Long memberId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        if (!question.getMember().getId().equals(memberId)) { // 질문 작성자만 삭제 가능
+            throw new GeneralException(ErrorStatus.NOT_QUESTION_AUTHOR);
+        }
+
+        questionRepository.delete(question);
+    }
 }

--- a/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
+++ b/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,5 +55,15 @@ public class QuestionController {
             @Parameter(description = "조회할 사용자 ID", example = "1")
             @PathVariable Long memberId) {
         return ApiResponse.onSuccess(questionService.getMyQuestions(memberId));
+    }
+
+    @Operation(summary = "질문 삭제 API", description = "특정 질문을 삭제합니다.")
+    @DeleteMapping("/questions/{questionId}/{memberId}")
+    public ApiResponse<String> deleteQuestion(
+            @PathVariable Long questionId,
+            @PathVariable Long memberId
+    ) {
+        questionService.deleteQuestion(questionId, memberId);
+        return ApiResponse.onSuccess("질문이 성공적으로 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #55 

## 📝작업 내용

질문, 댓글, 대댓글 삭제 API 구현 (삭제는 본인이 작성한 글만 가능)