### PR TITLE
feat: 홈화면 조회 API

### DIFF
--- a/src/main/java/com/picky/SpringbootApplication.java
+++ b/src/main/java/com/picky/SpringbootApplication.java
@@ -3,8 +3,10 @@ package com.picky;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class SpringbootApplication {
 

--- a/src/main/java/com/picky/config/WebConfig.java
+++ b/src/main/java/com/picky/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.picky.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173", "http://localhost:8080", "http://13.124.86.254")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/picky/config/WebConfig.java
+++ b/src/main/java/com/picky/config/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5173", "http://localhost:8080", "http://13.124.86.254")
+                .allowedOrigins("http://localhost:8080", "http://13.124.86.254")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "PATCH")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/picky/domain/ai/scheduler/AiSummaryScheduler.java
+++ b/src/main/java/com/picky/domain/ai/scheduler/AiSummaryScheduler.java
@@ -1,0 +1,76 @@
+package com.picky.domain.ai.scheduler;
+
+import com.picky.domain.ai.service.AiService;
+import com.picky.domain.ai.service.AiService.AIResponseDTO;
+import com.picky.domain.ai.service.QuestionAiUpdateService;
+import com.picky.domain.answer.entity.Answer;
+import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.repository.QuestionRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiSummaryScheduler {
+
+    private final QuestionRepository questionRepository;
+    private final AiService aiService;
+    private final QuestionAiUpdateService questionAiUpdateService;
+
+    @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 자정에 실행
+    public void summarizeHotTopic() {
+        log.info("[AiSummaryScheduler] 매시간 핫토픽 요약 작업 시작");
+
+        // 조회 종료 시점 = 이번 주 월요일 0시
+        LocalDateTime endOfLastWeek = LocalDate.now().atStartOfDay();
+        // 조회 시작 시점 = 종료 시점에서 일주일 전 (= 지난주 월요일 0시)
+        LocalDateTime startOfLastWeek = endOfLastWeek.minusWeeks(1);
+
+        log.info("[AiSummaryScheduler] 요약 대상 기간: {} ~ {}", startOfLastWeek, endOfLastWeek);
+
+        Optional<Question> hotQuestionOpt = questionRepository
+            .findTopQuestionBetween(startOfLastWeek, endOfLastWeek, PageRequest.of(0, 1))
+            .stream().findFirst();
+
+        if (hotQuestionOpt.isEmpty()) {
+            log.info("[AiSummaryScheduler] 이번 주에 질문이 없어 요약 작업을 종료합니다.");
+            return;
+        }
+
+        Question hotQuestion = hotQuestionOpt.get();
+
+        if (hotQuestion.getAiSummary() != null && !hotQuestion.getAiSummary().isEmpty()) {
+            log.info("[AiSummaryScheduler] 질문 ID {} 는 이미 요약이 되어 있습니다. 작업을 종료합니다.", hotQuestion.getId());
+            return;
+        }
+
+        log.info("[AiSummaryScheduler] 질문 ID {} 에 대해 AI 요약 작업을 시작합니다.", hotQuestion.getId());
+
+        List<String> comments = hotQuestion.getAnswers().stream()
+                                        .map(Answer::getContent)
+                                        .toList();
+
+        AIResponseDTO response = aiService.getSummaryAndHashtags(
+            hotQuestion.getTitle(),
+            hotQuestion.getContent(),
+            comments
+        ).block(); // AI 응답이 올 때까지 여기서 멈춤!
+
+        // 응답이 성공적으로 왔을 때만 업데이트
+        if (response != null) {
+            log.info("[AiSummaryScheduler] OpenAI로부터 받은 실제 응답: {}", response);
+            questionAiUpdateService.updateQuestionWithAiAnalysis(hotQuestion.getId(), response);
+            log.info("[AiSummaryScheduler] 질문 ID {} 에 대한 AI 요약 작업이 완료 및 저장되었습니다.", hotQuestion.getId());
+        } else {
+            log.error("[AiSummaryScheduler] AI 서비스로부터 응답을 받지 못했습니다.");
+        }
+    }
+}

--- a/src/main/java/com/picky/domain/ai/service/AiService.java
+++ b/src/main/java/com/picky/domain/ai/service/AiService.java
@@ -1,0 +1,102 @@
+package com.picky.domain.ai.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AiService {
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    private String createPrompt(String questionTitle, String questionContent, List<String> comments) {
+        String commentStr = String.join("\n- ", comments);
+
+        return String.format(
+            """
+            아래는 책에 대한 하나의 질문과 그에 대한 여러 댓글들입니다. 전체 내용을 분석해서 다음 두 가지 작업을 수행해주세요.
+
+            [질문 제목]
+            %s
+
+            [질문 내용]
+            %s
+
+            [댓글 목록]
+            - %s
+
+            ---
+
+            [작업]
+            1. 전체 토론 내용을 핵심만 요약해서 한 문장의 한국어로 작성해주세요.
+            2. 이 토론의 핵심을 나타내는 해시태그를 3개 생성해주세요. '#'으로 시작하고 콤마(,)로 구분해주세요. (예: #토론,#서사불쌍,#무한공감)
+
+            [출력 형식]
+            반드시 아래와 같은 JSON 형식으로만 응답해주세요. 다른 설명은 추가하지 마세요.
+            {
+              "summary": "요약 내용",
+              "hashtags": "#해시태그1,#해시태그2,#해시태그3"
+            }
+            """, questionTitle, questionContent, commentStr
+        );
+    }
+
+    public Mono<AIResponseDTO> getSummaryAndHashtags(String questionTitle, String questionContent, List<String> comments) {
+        String prompt = createPrompt(questionTitle, questionContent, comments);
+
+        List<Map<String, String>> messages = List.of(Map.of("role", "user", "content", prompt));
+        Map<String, Object> body = Map.of(
+            "model", "gpt-3.5-turbo",
+            "messages", messages,
+            "temperature", 0.7
+        );
+
+        return webClient.post()
+                        .uri(OPENAI_API_URL)
+                        .header("Authorization", "Bearer " + apiKey)
+                        .bodyValue(body)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .flatMap(responseBody -> {
+                            log.info("OpenAI Raw Response: {}", responseBody);
+
+                            try {
+                                JsonNode root = objectMapper.readTree(responseBody);
+                                String content = root.path("choices").get(0).path("message").path("content").asText();
+
+                                log.info("OpenAI content field: {}", content);
+
+                                JsonNode inner = objectMapper.readTree(content);
+                                String summary = inner.path("summary").asText();
+                                String hashtags = inner.path("hashtags").asText();
+
+                                log.info("Parsed summary={}, hashtags={}", summary, hashtags);
+
+                                return Mono.just(new AIResponseDTO(summary, hashtags));
+
+                            } catch (Exception e) {
+                                log.error("Failed to parse OpenAI response: {}", responseBody, e);
+                                return Mono.error(e);
+                            }
+                        })
+                        .doOnError(error -> log.error("Error while calling OpenAI API: {}", error.getMessage()));
+    }
+
+
+    public record AIResponseDTO(String summary, String hashtags){}
+}

--- a/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
+++ b/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
@@ -1,0 +1,29 @@
+package com.picky.domain.ai.service;
+
+import com.picky.apiPayload.code.status.ErrorStatus;
+import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.ai.service.AiService.AIResponseDTO;
+import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.repository.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+// DB 업뎃 담당
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class QuestionAiUpdateService {
+
+    private final QuestionRepository questionRepository;
+
+    @Transactional
+    public void updateQuestionWithAiAnalysis(Long questionId, AIResponseDTO response) {
+
+        Question question = questionRepository.findById(questionId)
+                                              .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        question.updateAIAnalysis(response.summary(), response.hashtags());
+    }
+}

--- a/src/main/java/com/picky/domain/home/service/HomeService.java
+++ b/src/main/java/com/picky/domain/home/service/HomeService.java
@@ -1,8 +1,7 @@
 package com.picky.domain.home.service;
 
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
-import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
-import java.util.List;
+import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBooksResponseDTO;
 
 public interface HomeService {
 
@@ -14,7 +13,7 @@ public interface HomeService {
 
     /**
      * 가장 많이 질문된 책 목록 조회
-     * @return List<MostQuestionedBookResponseDTO> 가장 많이 질문된 책 7권 정보 리스트
+     * @return List<MostQuestionedBooksResponseDTO> 가장 많이 질문된 책 7권 정보 리스트
      */
-     List<MostQuestionedBookResponseDTO> getMostQuestionedBooks();
+     MostQuestionedBooksResponseDTO getMostQuestionedBooks();
 }

--- a/src/main/java/com/picky/domain/home/service/HomeService.java
+++ b/src/main/java/com/picky/domain/home/service/HomeService.java
@@ -1,0 +1,12 @@
+package com.picky.domain.home.service;
+
+import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
+
+public interface HomeService {
+
+    /**
+     * 이번 주 핫 토픽 조회
+     * @return HotTopicResponseDTO 이번 주 핫 토픽 정보
+     */
+    HotTopicResponseDTO getHotTopic();
+}

--- a/src/main/java/com/picky/domain/home/service/HomeService.java
+++ b/src/main/java/com/picky/domain/home/service/HomeService.java
@@ -1,6 +1,8 @@
 package com.picky.domain.home.service;
 
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
+import java.util.List;
 
 public interface HomeService {
 
@@ -9,4 +11,10 @@ public interface HomeService {
      * @return HotTopicResponseDTO 이번 주 핫 토픽 정보
      */
     HotTopicResponseDTO getHotTopic();
+
+    /**
+     * 가장 많이 질문된 책 목록 조회
+     * @return List<MostQuestionedBookResponseDTO> 가장 많이 질문된 책 7권 정보 리스트
+     */
+     List<MostQuestionedBookResponseDTO> getMostQuestionedBooks();
 }

--- a/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
@@ -5,14 +5,15 @@ import com.picky.apiPayload.exception.GeneralException;
 import com.picky.domain.book.entity.Book;
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
 import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBooksResponseDTO;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.WeekFields;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class HomeServiceImpl implements HomeService {
     public HotTopicResponseDTO getHotTopic() {
 
         DateRange lastWeek = getLastWeekRange();
+        String weekInfo = getWeekInfoString(lastWeek.start()); // 주차 정보 생성
 
         Question question = questionRepository
             .findTopQuestionBetween(lastWeek.start(), lastWeek.end(), PageRequest.of(0, 1))
@@ -48,6 +50,7 @@ public class HomeServiceImpl implements HomeService {
                                   .questionTitle(question.getTitle())
                                   .aiSummary(question.getAiSummary())
                                   .hashtags(hashtagList)
+                                  .weekInfo(weekInfo)
                                   .likes(question.getQuestionLikes().size())
                                   .comments(question.getAnswers().size())
                                   .views(question.getViews())
@@ -55,23 +58,29 @@ public class HomeServiceImpl implements HomeService {
     }
 
     @Override
-    public List<MostQuestionedBookResponseDTO> getMostQuestionedBooks() {
+    public MostQuestionedBooksResponseDTO getMostQuestionedBooks() {
 
         DateRange lastWeek = getLastWeekRange();
+        String weekInfo = getWeekInfoString(lastWeek.start()); // 주차 정보 생성
 
         // 상위 7권 조회
         List<Book> books = questionRepository.findTopBooksByQuestionBetween(
             lastWeek.start(), lastWeek.end(), PageRequest.of(0, 7)
         );
 
-        return books.stream()
-                    .map(book -> MostQuestionedBookResponseDTO.builder()
-                                                              .bookId(book.getId())
-                                                              .bookTitle(book.getTitle())
-                                                              .bookAuthor(book.getAuthor())
-                                                              .bookCover(book.getCoverImage())
-                                                              .build())
-                    .collect(Collectors.toList());
+        List<MostQuestionedBookResponseDTO> response = books.stream()
+            .map(book -> MostQuestionedBookResponseDTO.builder()
+                                                      .bookId(book.getId())
+                                                      .bookTitle(book.getTitle())
+                                                      .bookAuthor(book.getAuthor())
+                                                      .bookCover(book.getCoverImage())
+                                                      .build())
+            .toList();
+
+        return MostQuestionedBooksResponseDTO.builder()
+            .weekInfo(weekInfo)
+            .books(response)
+            .build();
     }
 
     private DateRange getLastWeekRange() {
@@ -86,4 +95,11 @@ public class HomeServiceImpl implements HomeService {
     }
 
     private record DateRange(LocalDateTime start, LocalDateTime end) {}
+
+    private String getWeekInfoString(LocalDateTime date) {
+        WeekFields weekFields = WeekFields.of(DayOfWeek.MONDAY, 1);
+        int month = date.getMonthValue();
+        int weekOfMonth = date.get(weekFields.weekOfMonth());
+        return String.format("%d월 %d주차", month, weekOfMonth);
+    }
 }

--- a/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
@@ -2,7 +2,9 @@ package com.picky.domain.home.service;
 
 import com.picky.apiPayload.code.status.ErrorStatus;
 import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.book.entity.Book;
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import java.time.DayOfWeek;
@@ -10,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -19,20 +22,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class HomeServiceImpl implements HomeService {
+
     private final QuestionRepository questionRepository;
 
     @Override
     public HotTopicResponseDTO getHotTopic() {
 
-        // 조회 기준 시점 = 이번 주 월요일 0시
-        LocalDateTime thisMonday = LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay();
-
-        // 조회 기간 설정: 지난주 월요일 0시 ~ 이번 주 월요일 0시 전
-        LocalDateTime startOfLastWeek = thisMonday.minusWeeks(1);
-        LocalDateTime endOfLastWeek = thisMonday;
+        DateRange lastWeek = getLastWeekRange();
 
         Question question = questionRepository
-            .findTopQuestionBetween(startOfLastWeek, endOfLastWeek, PageRequest.of(0, 1))
+            .findTopQuestionBetween(lastWeek.start(), lastWeek.end(), PageRequest.of(0, 1))
             .stream().findFirst()
             .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
@@ -53,6 +52,38 @@ public class HomeServiceImpl implements HomeService {
                                   .comments(question.getAnswers().size())
                                   .views(question.getViews())
                                   .build();
-
     }
+
+    @Override
+    public List<MostQuestionedBookResponseDTO> getMostQuestionedBooks() {
+
+        DateRange lastWeek = getLastWeekRange();
+
+        // 상위 7권 조회
+        List<Book> books = questionRepository.findTopBooksByQuestionBetween(
+            lastWeek.start(), lastWeek.end(), PageRequest.of(0, 7)
+        );
+
+        return books.stream()
+                    .map(book -> MostQuestionedBookResponseDTO.builder()
+                                                              .bookId(book.getId())
+                                                              .bookTitle(book.getTitle())
+                                                              .bookAuthor(book.getAuthor())
+                                                              .bookCover(book.getCoverImage())
+                                                              .build())
+                    .collect(Collectors.toList());
+    }
+
+    private DateRange getLastWeekRange() {
+
+        // 조회 기준 시점: 이번 주 월요일 0시
+        LocalDateTime thisMonday = LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay();
+
+        // 조회 기간 설정: 지난주 월요일 0시 ~ 이번 주 월요일 0시 전
+        LocalDateTime startOfLastWeek = thisMonday.minusWeeks(1);
+
+        return new DateRange(startOfLastWeek, thisMonday);
+    }
+
+    private record DateRange(LocalDateTime start, LocalDateTime end) {}
 }

--- a/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
@@ -1,0 +1,58 @@
+package com.picky.domain.home.service;
+
+import com.picky.apiPayload.code.status.ErrorStatus;
+import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
+import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.repository.QuestionRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeServiceImpl implements HomeService {
+    private final QuestionRepository questionRepository;
+
+    @Override
+    public HotTopicResponseDTO getHotTopic() {
+
+        // 조회 기준 시점 = 이번 주 월요일 0시
+        LocalDateTime thisMonday = LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay();
+
+        // 조회 기간 설정: 지난주 월요일 0시 ~ 이번 주 월요일 0시 전
+        LocalDateTime startOfLastWeek = thisMonday.minusWeeks(1);
+        LocalDateTime endOfLastWeek = thisMonday;
+
+        Question question = questionRepository
+            .findTopQuestionBetween(startOfLastWeek, endOfLastWeek, PageRequest.of(0, 1))
+            .stream().findFirst()
+            .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        List<String> hashtagList = List.of();
+        if (question.getAiHashtags() != null && !question.getAiHashtags().isEmpty()) {
+            hashtagList = Arrays.asList(question.getAiHashtags().split(","));
+        }
+
+        return HotTopicResponseDTO.builder()
+                                  .questionId(question.getId())
+                                  .bookTitle(question.getBook().getTitle())
+                                  .bookAuthor(question.getBook().getAuthor())
+                                  .bookCover(question.getBook().getCoverImage())
+                                  .questionTitle(question.getTitle())
+                                  .aiSummary(question.getAiSummary())
+                                  .hashtags(hashtagList)
+                                  .likes(question.getQuestionLikes().size())
+                                  .comments(question.getAnswers().size())
+                                  .views(question.getViews())
+                                  .build();
+
+    }
+}

--- a/src/main/java/com/picky/domain/home/web/controller/HomeController.java
+++ b/src/main/java/com/picky/domain/home/web/controller/HomeController.java
@@ -4,10 +4,9 @@ import com.picky.apiPayload.ApiResponse;
 import com.picky.domain.ai.scheduler.AiSummaryScheduler;
 import com.picky.domain.home.service.HomeService;
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
-import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBooksResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,7 +39,7 @@ public class HomeController {
 
     @Operation(summary = "가장 많이 질문된 책 목록 조회 API", description = "이번 주에 가장 많이 질문된 책 7권을 조회합니다.")
     @GetMapping("/most-questioned-books")
-    public ApiResponse<List<MostQuestionedBookResponseDTO>>  getMostQuestionedBooks() {
+    public ApiResponse<MostQuestionedBooksResponseDTO>  getMostQuestionedBooks() {
         return ApiResponse.onSuccess(homeService.getMostQuestionedBooks());
     }
 }

--- a/src/main/java/com/picky/domain/home/web/controller/HomeController.java
+++ b/src/main/java/com/picky/domain/home/web/controller/HomeController.java
@@ -1,0 +1,38 @@
+package com.picky.domain.home.web.controller;
+
+import com.picky.apiPayload.ApiResponse;
+import com.picky.domain.ai.scheduler.AiSummaryScheduler;
+import com.picky.domain.home.service.HomeService;
+import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+@Tag(name = "홈 화면")
+public class HomeController {
+
+    private final HomeService homeService;
+    private final AiSummaryScheduler aiSummaryScheduler;
+
+    @Operation(summary = "이번 주 핫 토픽 조회 API", description = "이번 주에 가장 댓글이 많이 달린 질문글 1개를 조회합니다.")
+    @GetMapping("/hot-topic")
+    public ApiResponse<HotTopicResponseDTO> getHotTopic() {
+        return ApiResponse.onSuccess(homeService.getHotTopic());
+    }
+
+    @Profile("dev") // dev 환경에서만 활성화
+    @Operation(summary = "[테스트용] 핫 토픽 AI 요약 수동 실행 API", description = "스케줄러를 기다리지 않고 AI 요약 기능을 즉시 실행합니다.")
+    @PostMapping("/test/summarize")
+    public ApiResponse<String> triggerSummarize() {
+        aiSummaryScheduler.summarizeHotTopic();
+        return ApiResponse.onSuccess("AI 요약 작업이 수동으로 실행되었습니다. 서버 로그를 확인하세요.");
+    }
+}

--- a/src/main/java/com/picky/domain/home/web/controller/HomeController.java
+++ b/src/main/java/com/picky/domain/home/web/controller/HomeController.java
@@ -4,8 +4,10 @@ import com.picky.apiPayload.ApiResponse;
 import com.picky.domain.ai.scheduler.AiSummaryScheduler;
 import com.picky.domain.home.service.HomeService;
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,5 +36,11 @@ public class HomeController {
     public ApiResponse<String> triggerSummarize() {
         aiSummaryScheduler.summarizeHotTopic();
         return ApiResponse.onSuccess("AI 요약 작업이 수동으로 실행되었습니다. 서버 로그를 확인하세요.");
+    }
+
+    @Operation(summary = "가장 많이 질문된 책 목록 조회 API", description = "이번 주에 가장 많이 질문된 책 7권을 조회합니다.")
+    @GetMapping("/most-questioned-books")
+    public ApiResponse<List<MostQuestionedBookResponseDTO>>  getMostQuestionedBooks() {
+        return ApiResponse.onSuccess(homeService.getMostQuestionedBooks());
     }
 }

--- a/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
+++ b/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
@@ -27,4 +27,15 @@ public class HomeResponseDTO {
         private int comments;
         private int views;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MostQuestionedBookResponseDTO { // 질문이 가장 많은 책 응답
+        private Long bookId;
+        private String bookTitle;
+        private String bookAuthor;
+        private String bookCover;
+    }
 }

--- a/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
+++ b/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
@@ -1,0 +1,30 @@
+package com.picky.domain.home.web.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class HomeResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class HotTopicResponseDTO { // 이번 주 핫 토픽 응답
+        private Long questionId;
+
+        private String bookTitle;
+        private String bookAuthor;
+        private String bookCover;
+
+        private String questionTitle;
+        private String aiSummary;
+        private List<String> hashtags;
+
+        private int likes;
+        private int comments;
+        private int views;
+    }
+}

--- a/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
+++ b/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
@@ -23,9 +23,20 @@ public class HomeResponseDTO {
         private String aiSummary;
         private List<String> hashtags;
 
+        private String weekInfo; // "9월 1주차" 같은 정보
+
         private int likes;
         private int comments;
         private int views;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MostQuestionedBooksResponseDTO { // 질문이 가장 많은 책 응답
+        private List<MostQuestionedBookResponseDTO> books;
+        private String weekInfo;
     }
 
     @Getter

--- a/src/main/java/com/picky/domain/question/entity/Question.java
+++ b/src/main/java/com/picky/domain/question/entity/Question.java
@@ -53,6 +53,9 @@ public class Question extends BaseEntity {
   @Builder.Default
   private Boolean isAiGenerated = false;
 
+  private String aiSummary;
+  private String aiHashtags; // 해시태그는 ,로 구분된 문자열로 저장
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   @Builder.Default
@@ -67,4 +70,9 @@ public class Question extends BaseEntity {
   @Builder.Default
   @BatchSize(size = 100)
   private List<QuestionLike> questionLikes = new ArrayList<>();
+
+  public void updateAIAnalysis(String summary, String hashtags) {
+    this.aiSummary = summary;
+    this.aiHashtags = hashtags;
+  }
 }

--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -1,5 +1,6 @@
 package com.picky.domain.question.repository;
 
+import com.picky.domain.book.entity.Book;
 import com.picky.domain.question.entity.Question;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -58,4 +59,10 @@ public interface QuestionRepository extends JpaRepository<Question, Long>,
     @Query("SELECT q FROM Question q WHERE q.createdAt >= :startDate AND q.createdAt < :endDate ORDER BY SIZE(q.answers) DESC, q.views DESC")
     List<Question> findTopQuestionBetween(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Pageable pageable);
 
+    @Query("SELECT q.book FROM Question q WHERE q.createdAt >= :startDate AND q.createdAt < :endDate GROUP BY q.book ORDER BY COUNT(q) DESC")
+    List<Book> findTopBooksByQuestionBetween(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionRepository.java
@@ -1,8 +1,10 @@
 package com.picky.domain.question.repository;
 
 import com.picky.domain.question.entity.Question;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -52,4 +54,8 @@ public interface QuestionRepository extends JpaRepository<Question, Long>,
     @Modifying(clearAutomatically = true)
     @Query("update Question q set q.views = q.views + 1 where q.id = :id")
     int increaseViews(@Param("id") Long id);
+
+    @Query("SELECT q FROM Question q WHERE q.createdAt >= :startDate AND q.createdAt < :endDate ORDER BY SIZE(q.answers) DESC, q.views DESC")
+    List<Question> findTopQuestionBetween(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Pageable pageable);
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,10 @@ spring:
 aladin:
   api:
     key: ${ALADIN_API_KEY}
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+
 #naver:
 #  client:
 #    id: "네이버ClientId"


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #57 

## 📝작업 내용

- **핫 토픽**: AI 요약과 해시태그 생성을 위한 서비스 + 스케줄러 구현
  - 스케줄러는 홈화면 조회 시마다 OpenAI의 API를 호출하게 되면 토큰을 금방 소진할 것 같아 구현했고, 지난주 월요일 0시부터 이번주 월요일 0시 이전까지의 내용을 매주 자동으로 요약해 요약 내용과 해시태그를 DB에 저장(캐싱 느낌)하도록 했습니다. 이후 홈화면 조회 때는 DB에서 가져온 이 데이터를 보여주게 됩니다.
  - 따라서 지난 주 요약 느낌으로 변경됨에 따라 0월 0주차에 대한 요약인지 주차 정보(`weekInfo`)를 응답에 포함시켰습니다.

- **최다 질문**: DB에서 매번 가져와도 비용이 크지 않아 괜찮지만 통일을 위해 마찬가지로 지난 주 데이터를 기준으로 집계하도록 변경했습니다.

- **WebConfig 추가**: 이건 스웨거에서 직접 테스트 스케줄러 돌리는 API 실행 버튼 눌렀더니 CORS 정책에 막혀서 추가했습니다.

- _TODO: 가장 많이 나온 키워드 추가_