### PR TITLE
feat: token 재발급

### DIFF
--- a/src/main/java/com/picky/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/picky/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,31 @@
+package com.picky.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, length = 512)
+    private String tokenValue;
+
+    public RefreshToken(String email, String tokenValue) {
+        this.email = email;
+        this.tokenValue = tokenValue;
+    }
+
+    public void updateToken(String refreshToken) { // 여기에서 해도 될 지
+        this.tokenValue = refreshToken;
+    }
+}

--- a/src/main/java/com/picky/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/picky/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,18 @@
+package com.picky.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.picky.domain.auth.entity.RefreshToken;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByEmail(String email);
+
+    @Transactional
+    void deleteByEmail(String email);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #63 

## 📝작업 내용

> - access token과 refresh token 재발급과 로그아웃을 위해 refresh token을 db에 저장하도록 함

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 아직 다 완성하지 않았음! 재발급 기능 구현 부분 추가해야함