### PR TITLE
feat: 회원가입 및 로그인 로직 분리 구현

### DIFF
--- a/src/main/java/com/picky/domain/auth/service/AuthService.java
+++ b/src/main/java/com/picky/domain/auth/service/AuthService.java
@@ -1,7 +1,9 @@
 package com.picky.domain.auth.service;
 
 import com.picky.domain.auth.web.dto.AuthResponseDTO;
+import com.picky.domain.member.web.dto.MemberSignUpRequestDTO;
 
 public interface AuthService {
-    AuthResponseDTO loginOrSignUp(String firebaseToken);
+    AuthResponseDTO login(String firebaseToken);
+    AuthResponseDTO signUp(String firebaseToken, MemberSignUpRequestDTO memberSignUpRequestDTO);
 }

--- a/src/main/java/com/picky/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/picky/domain/auth/service/AuthServiceImpl.java
@@ -1,7 +1,6 @@
 package com.picky.domain.auth.service;
 
 import java.util.Collections;
-import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -19,9 +18,9 @@ import com.picky.domain.auth.TokenInfo;
 import com.picky.domain.auth.web.dto.AuthResponseDTO;
 import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.repository.MemberRepository;
+import com.picky.domain.member.web.dto.MemberSignUpRequestDTO;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
@@ -34,46 +33,63 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public AuthResponseDTO loginOrSignUp(String firebaseToken) {
-        FirebaseToken decodedToken;
-        try {
-            decodedToken = firebaseAuth.verifyIdToken(firebaseToken);
-        } catch (Exception e) {
-            throw new GeneralException(ErrorStatus._UNAUTHORIZED, "유효하지 않은 Firebase 토큰입니다.");
-        }
+    public AuthResponseDTO login(String firebaseToken) {
 
+        FirebaseToken decodedToken = verifyFirebaseToken(firebaseToken);
+        String email = decodedToken.getEmail();
+
+        Member member = memberRepository.findByEmail(email).orElseThrow(
+                () -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND, "가입되지 않은 회원입니다.")
+        );
+
+        TokenInfo tokenInfo = generateToken(member);
+
+        return AuthResponseDTO.builder()
+                .status(AuthResponseDTO.AuthStatus.LOGIN)
+                .tokenInfo(tokenInfo)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public AuthResponseDTO signUp(String firebaseToken, MemberSignUpRequestDTO memberSignUpRequestDTO) {
+        FirebaseToken decodedToken = verifyFirebaseToken(firebaseToken);
         String email = decodedToken.getEmail();
         log.info("decoded firebase email: {}", email);
 
-        Optional<Member> optionalMember = memberRepository.findByEmail(email);
-        boolean isNewUser = optionalMember.isEmpty();
+        memberRepository.findByEmail(email).ifPresent(member -> {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST, "이미 가입된 회원입니다.");
+        });
         log.info(email);
 
-        Member member = optionalMember.orElseGet(() -> {
+        Member newMember = Member.builder()
+                .email(email)
+                .name(memberSignUpRequestDTO.getName())
+                .nickname(memberSignUpRequestDTO.getNickname())
+                .roles(Collections.singletonList("USER"))
+                .build();
+        memberRepository.save(newMember);
 
-            String name = decodedToken.getName();
-            if (name == null || name.isBlank()) {
-                // 이메일에서 @ 앞부분을 이름으로 사용
-                name = email.split("@")[0];
-            }
-
-            Member newMember = Member.builder()
-                    .email(email)
-                    .name(name)
-                    .nickname("Picky" + email.split("@")[0])
-                    .roles(Collections.singletonList("USER"))
-                    .build();
-            return memberRepository.save(newMember);
-        });
-
-        Authentication authentication = new UsernamePasswordAuthenticationToken(member.getEmail(), null,
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
-
-        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+        TokenInfo tokenInfo = generateToken(newMember);
 
         return AuthResponseDTO.builder()
-                .status(isNewUser ? AuthResponseDTO.AuthStatus.SIGN_UP : AuthResponseDTO.AuthStatus.LOGIN)
+                .status(AuthResponseDTO.AuthStatus.SIGN_UP)
                 .tokenInfo(tokenInfo)
                 .build();
+    }
+
+    private FirebaseToken verifyFirebaseToken(String firebaseToken) {
+        try {
+            return firebaseAuth.verifyIdToken(firebaseToken);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED, "유효하지 않은 Firebase 토큰입니다.");
+        }
+    }
+
+    private TokenInfo generateToken(Member member) {
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member.getEmail(), null,
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")));
+        return jwtTokenProvider.generateToken(authentication);
+
     }
 }

--- a/src/main/java/com/picky/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/picky/domain/auth/web/controller/AuthController.java
@@ -2,16 +2,13 @@ package com.picky.domain.auth.web.controller;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.picky.apiPayload.ApiResponse;
 import com.picky.domain.auth.service.AuthService;
 import com.picky.domain.auth.web.dto.AuthResponseDTO;
+import com.picky.domain.member.web.dto.MemberSignUpRequestDTO;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -22,9 +19,15 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ApiResponse<AuthResponseDTO> loginOrSignUp(@Parameter(hidden = true) @RequestHeader("Authorization") String authorizationHeader) {
+    public ApiResponse<AuthResponseDTO> login(@Parameter(hidden = true) @RequestHeader("Authorization") String authorizationHeader) {
         String firebaseToken = extractToken(authorizationHeader);
-        return ApiResponse.onSuccess(authService.loginOrSignUp(firebaseToken));
+        return ApiResponse.onSuccess(authService.login(firebaseToken));
+    }
+
+    @PostMapping("/signup")
+    public ApiResponse<AuthResponseDTO> signUp(@RequestHeader("Authorization") String authorizationHeader, @RequestBody MemberSignUpRequestDTO memberSignUpRequestDTO) {
+        String firebaseToken = extractToken(authorizationHeader);
+        return ApiResponse.onSuccess(authService.signUp(firebaseToken, memberSignUpRequestDTO));
     }
 
     private String extractToken(String header) {

--- a/src/main/java/com/picky/domain/member/web/dto/MemberSignUpRequestDTO.java
+++ b/src/main/java/com/picky/domain/member/web/dto/MemberSignUpRequestDTO.java
@@ -7,10 +7,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberSignUpRequestDTO {
 
-    private String memberId;
-    private String email;
-    private String password;
     private String name;
-    public String nickname;
+    private String nickname;
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #69 

## 📝작업 내용

> 기존 loginOrSignUp 메서드 따로 분리
- 임의로 회원정보 넣던 걸 MemberSignUpReauestDTO에서 회원가입 정보 받아와서 저장
- AuthController에 signup api 추가

## 📷스크린샷 (선택)
<img width="1337" height="165" alt="image" src="https://github.com/user-attachments/assets/d8f9792d-fb29-4bc3-be91-e1f85da9b13a" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요