### PR TITLE
feat: 사용자 프로필 정보와 활동 내역 통계 조회

### DIFF
--- a/src/main/java/com/picky/domain/ai/service/AiService.java
+++ b/src/main/java/com/picky/domain/ai/service/AiService.java
@@ -4,12 +4,21 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Map;
+
+import com.picky.apiPayload.code.status.ErrorStatus;
+import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.ai.web.dto.AiQuestionRequestDTO;
+import com.picky.domain.book.entity.Book;
+import com.picky.domain.book.repository.BookRepository;
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +27,8 @@ public class AiService {
 
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
+    private final BookRepository bookRepository;
+    private final QuestionAiUpdateService questionAiUpdateService;
 
     @Value("${openai.api-key}")
     private String apiKey;
@@ -28,31 +39,31 @@ public class AiService {
         String commentStr = String.join("\n- ", comments);
 
         return String.format(
-            """
-            아래는 책에 대한 하나의 질문과 그에 대한 여러 댓글들입니다. 전체 내용을 분석해서 다음 두 가지 작업을 수행해주세요.
-
-            [질문 제목]
-            %s
-
-            [질문 내용]
-            %s
-
-            [댓글 목록]
-            - %s
-
-            ---
-
-            [작업]
-            1. 전체 토론 내용을 핵심만 요약해서 한 문장의 한국어로 작성해주세요.
-            2. 이 토론의 핵심을 나타내는 해시태그를 3개 생성해주세요. '#'으로 시작하고 콤마(,)로 구분해주세요. (예: #토론,#서사불쌍,#무한공감)
-
-            [출력 형식]
-            반드시 아래와 같은 JSON 형식으로만 응답해주세요. 다른 설명은 추가하지 마세요.
-            {
-              "summary": "요약 내용",
-              "hashtags": "#해시태그1,#해시태그2,#해시태그3"
-            }
-            """, questionTitle, questionContent, commentStr
+                """
+                        아래는 책에 대한 하나의 질문과 그에 대한 여러 댓글들입니다. 전체 내용을 분석해서 다음 두 가지 작업을 수행해주세요.
+                        
+                        [질문 제목]
+                        %s
+                        
+                        [질문 내용]
+                        %s
+                        
+                        [댓글 목록]
+                        - %s
+                        
+                        ---
+                        
+                        [작업]
+                        1. 전체 토론 내용을 핵심만 요약해서 한 문장의 한국어로 작성해주세요.
+                        2. 이 토론의 핵심을 나타내는 해시태그를 3개 생성해주세요. '#'으로 시작하고 콤마(,)로 구분해주세요. (예: #토론,#서사불쌍,#무한공감)
+                        
+                        [출력 형식]
+                        반드시 아래와 같은 JSON 형식으로만 응답해주세요. 다른 설명은 추가하지 마세요.
+                        {
+                          "summary": "요약 내용",
+                          "hashtags": "#해시태그1,#해시태그2,#해시태그3"
+                        }
+                        """, questionTitle, questionContent, commentStr
         );
     }
 
@@ -61,42 +72,118 @@ public class AiService {
 
         List<Map<String, String>> messages = List.of(Map.of("role", "user", "content", prompt));
         Map<String, Object> body = Map.of(
-            "model", "gpt-3.5-turbo",
-            "messages", messages,
-            "temperature", 0.7
+                "model", "gpt-3.5-turbo",
+                "messages", messages,
+                "temperature", 0.7
         );
 
         return webClient.post()
-                        .uri(OPENAI_API_URL)
-                        .header("Authorization", "Bearer " + apiKey)
-                        .bodyValue(body)
-                        .retrieve()
-                        .bodyToMono(String.class)
-                        .flatMap(responseBody -> {
-                            log.info("OpenAI Raw Response: {}", responseBody);
+                .uri(OPENAI_API_URL)
+                .header("Authorization", "Bearer " + apiKey)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMap(responseBody -> {
+                    log.info("OpenAI Raw Response: {}", responseBody);
 
-                            try {
-                                JsonNode root = objectMapper.readTree(responseBody);
-                                String content = root.path("choices").get(0).path("message").path("content").asText();
+                    try {
+                        JsonNode root = objectMapper.readTree(responseBody);
+                        String content = root.path("choices").get(0).path("message").path("content").asText();
 
-                                log.info("OpenAI content field: {}", content);
+                        log.info("OpenAI content field: {}", content);
 
-                                JsonNode inner = objectMapper.readTree(content);
-                                String summary = inner.path("summary").asText();
-                                String hashtags = inner.path("hashtags").asText();
+                        JsonNode inner = objectMapper.readTree(content);
+                        String summary = inner.path("summary").asText();
+                        String hashtags = inner.path("hashtags").asText();
 
-                                log.info("Parsed summary={}, hashtags={}", summary, hashtags);
+                        log.info("Parsed summary={}, hashtags={}", summary, hashtags);
 
-                                return Mono.just(new AIResponseDTO(summary, hashtags));
+                        return Mono.just(new AIResponseDTO(summary, hashtags));
 
-                            } catch (Exception e) {
-                                log.error("Failed to parse OpenAI response: {}", responseBody, e);
-                                return Mono.error(e);
-                            }
-                        })
-                        .doOnError(error -> log.error("Error while calling OpenAI API: {}", error.getMessage()));
+                    } catch (Exception e) {
+                        log.error("Failed to parse OpenAI response: {}", responseBody, e);
+                        return Mono.error(e);
+                    }
+                })
+                .doOnError(error -> log.error("Error while calling OpenAI API: {}", error.getMessage()));
     }
 
 
-    public record AIResponseDTO(String summary, String hashtags){}
+    public record AIResponseDTO(String summary, String hashtags) {
+    }
+
+    private String createQuestionPrompt(String bookTitle, String author, String theme) {
+        return String.format(
+                """
+                당신은 독서 토론을 위한 질문 생성기입니다.
+                아래 정보를 참고해서 주제에 맞는 질문 1개를 만들어주세요.
+    
+                [책 제목]
+                %s
+    
+                [저자]
+                %s
+    
+                [선택된 주제]
+                %s
+    
+                ---
+    
+                [요구사항]
+                1. 질문은 책의 내용을 기반으로 토론할 수 있어야 합니다.
+                2. 질문은 한국어로 작성해주세요.
+                3. 반드시 JSON 형식으로만 응답해주세요.
+    
+                [출력 형식]
+                {
+                  "title": "질문 제목",
+                  "content": "질문 내용"
+                }
+                """, bookTitle, author, theme
+        );
+    }
+
+    public Mono<QuestionPostResponseDTO> generateQuestion(AiQuestionRequestDTO request, Member member) {
+        Book book = bookRepository.findById(request.id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+
+        String prompt = createQuestionPrompt(book.getTitle(), book.getAuthor(), request.getQuestionType());
+
+        List<Map<String, String>> messages = List.of(Map.of("role", "user", "content", prompt));
+        Map<String, Object> body = Map.of(
+                "model", "gpt-3.5-turbo",
+                "messages", messages,
+                "temperature", 0.8
+        );
+
+        return webClient.post()
+                .uri(OPENAI_API_URL)
+                .header("Authorization", "Bearer " + apiKey)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(String.class)
+                .flatMap(responseBody -> {
+                    log.info("OpenAI Raw Response (Question): {}", responseBody);
+                    try {
+                        JsonNode root = objectMapper.readTree(responseBody);
+                        String content = root.path("choices").get(0).path("message").path("content").asText();
+
+                        JsonNode inner = objectMapper.readTree(content);
+                        String title = inner.path("title").asText();
+                        String questionContent = inner.path("content").asText();
+
+                        GeneratedQuestionDTO dto = new GeneratedQuestionDTO(title, questionContent);
+
+                        return Mono.fromCallable(() -> questionAiUpdateService.saveGeneratedQuestion(request, member, dto))
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .map(QuestionPostResponseDTO::new);
+                    } catch (Exception e) {
+                        log.error("Failed to parse generated question response: {}", responseBody, e);
+                        return Mono.error(e);
+                    }
+                });
+    }
+
+    public record GeneratedQuestionDTO(String title, String content) {}
 }

--- a/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
+++ b/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
@@ -3,6 +3,11 @@ package com.picky.domain.ai.service;
 import com.picky.apiPayload.code.status.ErrorStatus;
 import com.picky.apiPayload.exception.GeneralException;
 import com.picky.domain.ai.service.AiService.AIResponseDTO;
+import com.picky.domain.ai.web.dto.AiQuestionRequestDTO;
+import com.picky.domain.book.entity.Book;
+import com.picky.domain.book.repository.BookRepository;
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.member.repository.MemberRepository;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuestionAiUpdateService {
 
     private final QuestionRepository questionRepository;
+    private final MemberRepository memberRepository;
+    private final BookRepository bookRepository;
 
     @Transactional
     public void updateQuestionWithAiAnalysis(Long questionId, AIResponseDTO response) {
@@ -25,5 +32,21 @@ public class QuestionAiUpdateService {
                                               .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
         question.updateAIAnalysis(response.summary(), response.hashtags());
+    }
+
+    @Transactional
+    public Question saveGeneratedQuestion(AiQuestionRequestDTO request, Member member, AiService.GeneratedQuestionDTO dto) {
+        Book book = bookRepository.findById(request.getId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_NOT_FOUND));
+
+        Question question = Question.builder()
+                .book(book)
+                .member(member)
+                .title(dto.title())
+                .content(dto.content())
+                .isAiGenerated(true) // AI 생성된 질문임을 표시
+                .build();
+
+        return questionRepository.save(question);
     }
 }

--- a/src/main/java/com/picky/domain/ai/web/controller/AiController.java
+++ b/src/main/java/com/picky/domain/ai/web/controller/AiController.java
@@ -1,0 +1,36 @@
+package com.picky.domain.ai.web.controller;
+
+import com.picky.domain.ai.service.AiService;
+import com.picky.domain.ai.service.QuestionAiUpdateService;
+import com.picky.domain.auth.CustomerUserDetails;
+import com.picky.domain.ai.web.dto.AiQuestionRequestDTO;
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+@Tag(name = "ai")
+public class AiController {
+
+    private final AiService aiService;
+    private final QuestionAiUpdateService questionAiUpdateService;
+
+    @PostMapping("/generate-question")
+    public Mono<ResponseEntity<QuestionPostResponseDTO>> generateQuestion(
+            @AuthenticationPrincipal CustomerUserDetails customerUserDetails,
+            @Valid @RequestBody AiQuestionRequestDTO questionRequestDTO
+    ) {
+        Member currentMember = customerUserDetails.getMember();
+        return aiService.generateQuestion(questionRequestDTO, currentMember)
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/picky/domain/ai/web/dto/AiQuestionRequestDTO.java
+++ b/src/main/java/com/picky/domain/ai/web/dto/AiQuestionRequestDTO.java
@@ -1,0 +1,18 @@
+package com.picky.domain.ai.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@Schema(description = "질문 생성을 위한 요청 객체")
+public class AiQuestionRequestDTO {
+
+    @NotNull(message = "book id는 필수값입니다.")
+    @Schema(description = "book id", example = "1")
+    public Long id;
+
+    @NotNull(message = "주제는 필수값입니다.")
+    @Schema(description = "질문 생성을 위한 주제", example = "THEME")
+    public String questionType;
+}

--- a/src/main/java/com/picky/domain/member/service/MemberService.java
+++ b/src/main/java/com/picky/domain/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.picky.domain.member.service;
 
 import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.web.dto.MemberResponseDTO;
+import com.picky.domain.member.web.dto.MyMenuResponseDTO;
 import com.picky.domain.member.web.dto.PatchMemberRequestDTO;
 
 public interface MemberService {
@@ -22,6 +23,8 @@ public interface MemberService {
      * @return MemberResponseDTO
      */
     MemberResponseDTO patchMember(Member member, PatchMemberRequestDTO request);
+
+    MyMenuResponseDTO getMyMenu(Long memberId);
 
     void validateNickname(String nickname);
 }

--- a/src/main/java/com/picky/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/picky/domain/member/service/MemberServiceImpl.java
@@ -6,6 +6,8 @@ import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.entity.QMember;
 import com.picky.domain.member.repository.MemberRepository;
 import com.picky.domain.member.web.dto.MemberResponseDTO;
+import com.picky.domain.member.web.dto.MemberStatusDTO;
+import com.picky.domain.member.web.dto.MyMenuResponseDTO;
 import com.picky.domain.member.web.dto.PatchMemberRequestDTO;
 import com.picky.global.enums.DataStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -63,5 +65,26 @@ public class MemberServiceImpl implements MemberService {
             log.error("프로필 수정 실패", e);
             throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
         }
+    }
+
+    @Override
+    public MyMenuResponseDTO getMyMenu(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new GeneralException((ErrorStatus.MEMBER_NOT_FOUND)));
+
+        long totalBooks = member.getBookShelves().size();
+        long questions = member.getQuestions().size();
+        long answers = member.getAnswers().size();
+
+        MemberResponseDTO memberResponseDTO = MemberResponseDTO.fromEntity(member);
+        MemberStatusDTO memberStatusDTO = MemberStatusDTO.builder()
+                .totalBooks(totalBooks)
+                .questions(questions)
+                .answers(answers)
+                .build();
+
+        return MyMenuResponseDTO.builder()
+                .user(memberResponseDTO)
+                .stats(memberStatusDTO)
+                .build();
     }
 }

--- a/src/main/java/com/picky/domain/member/web/controller/MemberController.java
+++ b/src/main/java/com/picky/domain/member/web/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.picky.domain.auth.CustomerUserDetails;
 import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.service.MemberService;
 import com.picky.domain.member.web.dto.MemberResponseDTO;
+import com.picky.domain.member.web.dto.MyMenuResponseDTO;
 import com.picky.domain.member.web.dto.PatchMemberRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -30,6 +31,16 @@ public class MemberController {
         Member currentMember = customerUserDetails.getMember();
         MemberResponseDTO memberResponseDTO = MemberResponseDTO.fromEntity(currentMember);
         return ApiResponse.onSuccess(memberResponseDTO);
+    }
+
+    @Operation(summary = "마이메뉴 조회 API", description = "마이메뉴에서 필요한 정보를 조회합니다.")
+    @GetMapping("/mymenu")
+    public ApiResponse<MyMenuResponseDTO> getMyMenu(
+            @AuthenticationPrincipal CustomerUserDetails customerUserDetails
+    ) {
+        Member currentMember = customerUserDetails.getMember();
+        MyMenuResponseDTO myMenuResponseDTO = memberService.getMyMenu(currentMember.getId());
+        return ApiResponse.onSuccess(myMenuResponseDTO);
     }
 
     @Operation(summary = "내 정보 수정 API", description = "현재 로그인한 사용자의 정보를 수정합니다.")

--- a/src/main/java/com/picky/domain/member/web/dto/MemberStatusDTO.java
+++ b/src/main/java/com/picky/domain/member/web/dto/MemberStatusDTO.java
@@ -1,0 +1,20 @@
+package com.picky.domain.member.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 활동 통계 DTO")
+public class MemberStatusDTO {
+
+    @Schema(example = "12", description = "총 독서량")
+    private long totalBooks;
+
+    @Schema(example = "21", description = "작성한 질문 수")
+    private long questions;
+
+    @Schema(example = "8", description = "작성한 답변 수")
+    private long answers;
+}

--- a/src/main/java/com/picky/domain/member/web/dto/MyMenuResponseDTO.java
+++ b/src/main/java/com/picky/domain/member/web/dto/MyMenuResponseDTO.java
@@ -1,0 +1,14 @@
+package com.picky.domain.member.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "마이메뉴 조회 응답 DTO")
+public class MyMenuResponseDTO {
+
+    private MemberResponseDTO user;
+    private MemberStatusDTO stats;
+}

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -2,6 +2,8 @@ package com.picky.domain.question.web.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import com.picky.domain.question.entity.Question;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,14 @@ public class QuestionResponseDTO {
         private int page;
         private Boolean isAI;
         private LocalDateTime createdAt;
+
+        public QuestionPostResponseDTO(Question question) {
+            this.id = question.getId();
+            this.title = question.getTitle();
+            this.content = question.getContent();
+            this.isAI = question.getIsAiGenerated();
+            this.createdAt = question.getCreatedAt();
+        }
     }
 
     @Getter

--- a/src/main/java/com/picky/global/enums/QuestionType.java
+++ b/src/main/java/com/picky/global/enums/QuestionType.java
@@ -1,0 +1,5 @@
+package com.picky.global.enums;
+
+public enum QuestionType {
+    THEME, CHARACTER, STRUCTURE, CONTEXT
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #87 

## 📝작업 내용

- 기존 구현된 프로필 정보 조회 용도인 MemberResponseDTO와 사용자 활동 내역 통계를 나타내는 MemberStatusDTO를 통합하여 MyMenuResponseDTO로 나타냄
- 배포 DB에 테스트용으로 내서재에 책 추가 후 질문과 답변 생성해둠

## 📷스크린샷 (선택)

<img width="1775" height="554" alt="image" src="https://github.com/user-attachments/assets/30a9fb1b-0b2c-4ad0-8063-f15720f823ad" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요