### PR TITLE
feat: 홈화면 AI 키워드 조회 및 멤버 정보 수정

### DIFF
--- a/src/main/java/com/picky/domain/ai/service/AiService.java
+++ b/src/main/java/com/picky/domain/ai/service/AiService.java
@@ -1,7 +1,10 @@
 package com.picky.domain.ai.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picky.domain.question.entity.enums.Keyword;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -16,6 +19,7 @@ import com.picky.domain.member.entity.Member;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -317,4 +321,71 @@ public class AiService {
     }
     public record GeneratedAnswerDTO(String content) {}
 
+    public Mono<List<String>> getKeywords(String questionTitle, String questionContent) {
+        String prompt = createKeywordPrompt(questionTitle, questionContent);
+
+        List<Map<String, String>> messages = List.of(Map.of("role", "user", "content", prompt));
+        Map<String, Object> body = Map.of(
+            "model", "gpt-3.5-turbo",
+            "messages", messages,
+            "temperature", 0.2
+        );
+
+        return webClient.post()
+                        .uri(OPENAI_API_URL)
+                        .header("Authorization", "Bearer " + apiKey)
+                        .bodyValue(body)
+                        .retrieve()
+                        .bodyToMono(String.class)
+                        .flatMap(responseBody -> {
+                            log.info("OpenAI Raw Response (Keywords): {}", responseBody);
+                            try {
+                                JsonNode root = objectMapper.readTree(responseBody);
+                                String content = root.path("choices").get(0).path("message").path("content").asText();
+
+                                int startIndex = content.indexOf('[');
+                                int endIndex = content.lastIndexOf(']');
+
+                                if (startIndex != -1 && endIndex != -1 && startIndex < endIndex) {
+                                    String jsonArrayString = content.substring(startIndex, endIndex + 1);
+                                    List<String> keywords = objectMapper.readValue(jsonArrayString, new TypeReference<>() {});
+                                    log.info("Successfully parsed keywords: {}", keywords);
+                                    return Mono.just(keywords);
+                                } else {
+                                    // 만약 응답에서 '[' 와 ']'를 찾지 못하면 에러를 발생
+                                    log.error("Could not find a valid JSON array in the content: {}", content);
+                                    return Mono.error(new Exception("Invalid JSON format from AI: " + content));
+                                }
+
+                            } catch (Exception e) {
+                                log.error("Failed to parse keywords response: {}", responseBody, e);
+                                return Mono.error(e);
+                            }
+                        });
+    }
+
+    private String createKeywordPrompt(String questionTitle, String questionContent) {
+        // Keyword Enum에 추가한 헬퍼 메서드 사용
+        String keywordList = Keyword.getPromptValuesAsString();
+
+        return String.format(
+            """
+            [지시]
+            다음 [질문]을 분석하고, 아래 [키워드 목록]에서 가장 관련성 높은 키워드를 정확히 3개만 선택해주세요.
+
+            [질문 제목]
+            %s
+
+            [질문 내용]
+            %s
+
+            [키워드 목록]
+            %s
+
+            [출력 형식]
+            - ["키워드1", "키워드2", "키워드3"] 형태의 JSON 배열로만 응답해주세요.
+            - 다른 설명은 절대 추가하지 마세요.
+            """, questionTitle, questionContent, keywordList
+        );
+    }
 }

--- a/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
+++ b/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
@@ -9,11 +9,20 @@ import com.picky.domain.answer.repository.AnswerRepository;
 import com.picky.domain.book.entity.Book;
 import com.picky.domain.book.repository.BookRepository;
 import com.picky.domain.member.entity.Member;
+import com.picky.domain.question.entity.AiHashtag;
 import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.entity.QuestionKeyword;
+import com.picky.domain.question.entity.enums.Keyword;
 import com.picky.domain.question.entity.enums.QuestionType;
+import com.picky.domain.question.repository.QuestionKeywordRepository;
 import com.picky.domain.question.repository.QuestionRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,15 +35,7 @@ public class QuestionAiUpdateService {
     private final QuestionRepository questionRepository;
     private final AnswerRepository answerRepository;
     private final BookRepository bookRepository;
-
-    @Transactional
-    public void updateQuestionWithAiAnalysis(Long questionId, AIResponseDTO response) {
-
-        Question question = questionRepository.findById(questionId)
-                                              .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
-
-        question.updateAIAnalysis(response.summary(), response.hashtags());
-    }
+    private final QuestionKeywordRepository questionKeywordRepository;
 
     @Transactional
     public Question saveGeneratedQuestion(AiQuestionRequestDTO request, Member member, AiService.GeneratedQuestionDTO dto) {
@@ -68,5 +69,45 @@ public class QuestionAiUpdateService {
                 .build();
 
         return answerRepository.save(answer);
+    }
+
+    @Async
+    @Transactional
+    public void saveKeywords(Long questionId, List<String> keywordStrings) {
+        Question question = questionRepository.findById(questionId)
+                                              .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        if (keywordStrings != null) {
+            List<QuestionKeyword> questionKeywords = keywordStrings.stream()
+                                                                   .map(keywordStr -> {
+                                                                       // Keyword Enum에 추가한 헬퍼 메서드 사용
+                                                                       Keyword keywordEnum = Keyword.fromPromptValue(keywordStr);
+                                                                       if (keywordEnum != null) {
+                                                                           return QuestionKeyword.builder()
+                                                                                                 .question(question)
+                                                                                                 .keyword(keywordEnum)
+                                                                                                 .build();
+                                                                       }
+                                                                       return null;
+                                                                   })
+                                                                   .filter(Objects::nonNull)
+                                                                   .collect(Collectors.toList());
+
+            questionKeywordRepository.saveAll(questionKeywords);
+            log.info("[Async] 질문 ID {} 에 대한 키워드 저장 완료", questionId);
+        }
+    }
+
+    @Transactional
+    public void updateQuestionWithAiAnalysis(Long questionId, AIResponseDTO response) {
+        Question question = questionRepository.findById(questionId)
+                                              .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        List<AiHashtag> hashtags = Arrays.stream(response.hashtags().split(","))
+                                         .map(String::trim)
+                                         .map(tag -> AiHashtag.builder().question(question).tag(tag).build())
+                                         .collect(Collectors.toList());
+
+        question.updateAIAnalysis(response.summary(), hashtags);
     }
 }

--- a/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
+++ b/src/main/java/com/picky/domain/ai/service/QuestionAiUpdateService.java
@@ -71,7 +71,6 @@ public class QuestionAiUpdateService {
         return answerRepository.save(answer);
     }
 
-    @Async
     @Transactional
     public void saveKeywords(Long questionId, List<String> keywordStrings) {
         Question question = questionRepository.findById(questionId)
@@ -80,7 +79,6 @@ public class QuestionAiUpdateService {
         if (keywordStrings != null) {
             List<QuestionKeyword> questionKeywords = keywordStrings.stream()
                                                                    .map(keywordStr -> {
-                                                                       // Keyword Enum에 추가한 헬퍼 메서드 사용
                                                                        Keyword keywordEnum = Keyword.fromPromptValue(keywordStr);
                                                                        if (keywordEnum != null) {
                                                                            return QuestionKeyword.builder()
@@ -94,7 +92,7 @@ public class QuestionAiUpdateService {
                                                                    .collect(Collectors.toList());
 
             questionKeywordRepository.saveAll(questionKeywords);
-            log.info("[Async] 질문 ID {} 에 대한 키워드 저장 완료", questionId);
+            log.info("질문 ID {} 에 대한 키워드 저장 완료", questionId);
         }
     }
 

--- a/src/main/java/com/picky/domain/answer/service/AnswerService.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerService.java
@@ -31,7 +31,7 @@ public interface AnswerService {
      * @param questionId 조회할 질문 ID
      * @return 해당 질문에 대한 답변 목록 DTO
      */
-    AnswerListResponseDTO getAnswersByQuestion(Long questionId, String sort);
+    AnswerListResponseDTO getAnswersByQuestion(Long questionId, Long memberId, String sort);
 
     /**
      * 특정 답변을 삭제합니다.

--- a/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
@@ -116,7 +116,7 @@ public class AnswerServiceImpl implements AnswerService {
     }
 
     @Override
-    public AnswerListResponseDTO getAnswersByQuestion(Long questionId, String sort) {
+    public AnswerListResponseDTO getAnswersByQuestion(Long questionId, Long memberId, String sort) {
 
         questionRepository.findById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
@@ -127,7 +127,7 @@ public class AnswerServiceImpl implements AnswerService {
             .filter(a -> a.getParentAnswer() != null) // 이건 전부 대댓글
             .collect(Collectors.groupingBy(
                 a -> a.getParentAnswer().getId(), // 부모 댓글 id 기준으로 묶기
-                Collectors.mapping(this::convertToAnswerInfoDTO, Collectors.toList())
+                Collectors.mapping(a -> convertToAnswerInfoDTO(a, memberId), Collectors.toList())
             ));
 
         // 부모 댓글만 필터링
@@ -142,15 +142,18 @@ public class AnswerServiceImpl implements AnswerService {
 
         // DTO 변환
         List<AnswerInfoResponseDTO> responseDTOs = parentStream
-            .map(parent -> AnswerInfoResponseDTO.builder()
+            .map(parent -> {boolean isAuthor = parent.getMember().getId().equals(memberId);
+                return AnswerInfoResponseDTO.builder()
                                                 .id(parent.getId())
                                                 .content(parent.getContent())
+                                                .authorId(parent.getMember().getId())
                                                 .author(parent.getMember().getNickname())
                                                 .profileImg(parent.getMember().getProfileImg())
                                                 .isAI(parent.getIsAiGenerated())
                                                 .createdAt(parent.getCreatedAt())
+                                                .isAuthor(isAuthor)
                                                 .childrenAnswers(childrenMap.getOrDefault(parent.getId(), Collections.emptyList())) // 대댓글은 항상 오래된순
-                                                .build()
+                                                .build();}
             )
             .collect(Collectors.toList());
 
@@ -159,14 +162,18 @@ public class AnswerServiceImpl implements AnswerService {
                 .build();
     }
 
-    private AnswerInfoResponseDTO convertToAnswerInfoDTO(Answer answer) {
+    private AnswerInfoResponseDTO convertToAnswerInfoDTO(Answer answer, Long memberId) {
+        boolean isAuthor = answer.getMember().getId().equals(memberId);
+
         return AnswerInfoResponseDTO.builder()
                 .id(answer.getId())
                 .content(answer.getContent())
+                .authorId(answer.getMember().getId())
                 .author(answer.getMember().getNickname())
                 .profileImg(answer.getMember().getProfileImg())
                 .isAI(answer.getIsAiGenerated())
                 .createdAt(answer.getCreatedAt())
+                .isAuthor(isAuthor)
                 .childrenAnswers(Collections.emptyList())
                 .build();
     }

--- a/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
+++ b/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
@@ -42,8 +42,9 @@ public class AnswerController {
 
     @Operation(summary = "질문별 답변 조회 API", description = "특정 질문에 대한 모든 답변을 조회합니다.")
     @GetMapping("/questions/{questionId}/answers")
-    public ApiResponse<AnswerListResponseDTO> getAnswersByQuestion(@PathVariable Long questionId, @Parameter(description = "정렬 기준 (latest: 최신순, oldest: 오래된 순)", required = false) @RequestParam(defaultValue = "oldest") String sort) {
-        return ApiResponse.onSuccess(answerService.getAnswersByQuestion(questionId, sort));
+    public ApiResponse<AnswerListResponseDTO> getAnswersByQuestion(@PathVariable Long questionId, @AuthenticationPrincipal CustomerUserDetails customerUserDetails, @Parameter(description = "정렬 기준 (latest: 최신순, oldest: 오래된 순)", required = false) @RequestParam(defaultValue = "oldest") String sort) {
+        Long memberId = customerUserDetails.getMember().getId();
+        return ApiResponse.onSuccess(answerService.getAnswersByQuestion(questionId, memberId, sort));
     }
 
     @Operation(summary = "답변 삭제 API", description = "특정 답변을 삭제합니다.")

--- a/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
+++ b/src/main/java/com/picky/domain/answer/web/controller/AnswerController.java
@@ -5,11 +5,13 @@ import com.picky.domain.answer.service.AnswerService;
 import com.picky.domain.answer.web.dto.AnswerRequestDTO.AnswerCreateRequestDTO;
 import com.picky.domain.answer.web.dto.AnswerResponseDTO.AnswerCreateResponseDTO;
 import com.picky.domain.answer.web.dto.AnswerResponseDTO.AnswerListResponseDTO;
+import com.picky.domain.auth.CustomerUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,12 +30,13 @@ public class AnswerController {
     private final AnswerService answerService;
 
     @Operation(summary = "답변 등록 API", description = "특정 질문에 대한 답변을 등록합니다.")
-    @PostMapping("/questions/{questionId}/answers/{memberId}")
+    @PostMapping("/questions/{questionId}/answers")
     public ApiResponse<AnswerCreateResponseDTO> createAnswer(
         @PathVariable Long questionId,
-        @PathVariable Long memberId,
+        @AuthenticationPrincipal CustomerUserDetails customerUserDetails,
         @Valid @RequestBody AnswerCreateRequestDTO request
     ) {
+        Long memberId = customerUserDetails.getMember().getId();
         return ApiResponse.onSuccess(answerService.createAnswer(questionId, memberId, request));
     }
 
@@ -44,11 +47,12 @@ public class AnswerController {
     }
 
     @Operation(summary = "답변 삭제 API", description = "특정 답변을 삭제합니다.")
-    @DeleteMapping("/answers/{answerId}/{memberId}")
+    @DeleteMapping("/answers/{answerId}")
     public ApiResponse<String> deleteAnswer(
         @PathVariable Long answerId,
-        @PathVariable Long memberId
+        @AuthenticationPrincipal CustomerUserDetails customerUserDetails
     ) {
+        Long memberId = customerUserDetails.getMember().getId();
         answerService.deleteAnswer(answerId, memberId);
         return ApiResponse.onSuccess("답변이 성공적으로 삭제되었습니다.");
     }

--- a/src/main/java/com/picky/domain/answer/web/dto/AnswerResponseDTO.java
+++ b/src/main/java/com/picky/domain/answer/web/dto/AnswerResponseDTO.java
@@ -68,10 +68,12 @@ public class AnswerResponseDTO {
     public static class AnswerInfoResponseDTO {
         private Long id;
         private String content;
+        private Long authorId;
         private String author; // 작성자 이름
         private String profileImg; // 작성자 프로필 이미지
         private Boolean isAI;
         private LocalDateTime createdAt;
+        private Boolean isAuthor;
         @Schema(description = "대댓글 목록")
         private List<AnswerInfoResponseDTO> childrenAnswers; // 대댓글 목록
     }

--- a/src/main/java/com/picky/domain/home/service/HomeService.java
+++ b/src/main/java/com/picky/domain/home/service/HomeService.java
@@ -2,6 +2,7 @@ package com.picky.domain.home.service;
 
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
 import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBooksResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.WeeklyKeywordResponseDTO;
 
 public interface HomeService {
 
@@ -16,4 +17,10 @@ public interface HomeService {
      * @return List<MostQuestionedBooksResponseDTO> 가장 많이 질문된 책 7권 정보 리스트
      */
      MostQuestionedBooksResponseDTO getMostQuestionedBooks();
+
+     /**
+      * 이번 주 키워드 TOP 3 조회
+      * @return WeeklyKeywordResponseDTO 이번 주 키워드 TOP 3 정보
+      */
+    WeeklyKeywordResponseDTO getWeeklyTopKeywords();
 }

--- a/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
+++ b/src/main/java/com/picky/domain/home/service/HomeServiceImpl.java
@@ -6,15 +6,21 @@ import com.picky.domain.book.entity.Book;
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
 import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBookResponseDTO;
 import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBooksResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.WeeklyKeywordResponseDTO;
+import com.picky.domain.question.entity.AiHashtag;
 import com.picky.domain.question.entity.Question;
+import com.picky.domain.question.repository.QuestionKeywordRepository;
 import com.picky.domain.question.repository.QuestionRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.WeekFields;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,9 +28,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class HomeServiceImpl implements HomeService {
 
     private final QuestionRepository questionRepository;
+    private final QuestionKeywordRepository questionKeywordRepository;
 
     @Override
     public HotTopicResponseDTO getHotTopic() {
@@ -37,10 +45,9 @@ public class HomeServiceImpl implements HomeService {
             .stream().findFirst()
             .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
-        List<String> hashtagList = List.of();
-        if (question.getAiHashtags() != null && !question.getAiHashtags().isEmpty()) {
-            hashtagList = Arrays.asList(question.getAiHashtags().split(","));
-        }
+        List<String> hashtagList = question.getAiHashtags().stream()
+                                           .map(AiHashtag::getTag)
+                                           .collect(Collectors.toList());
 
         return HotTopicResponseDTO.builder()
                                   .questionId(question.getId())
@@ -101,5 +108,43 @@ public class HomeServiceImpl implements HomeService {
         int month = date.getMonthValue();
         int weekOfMonth = date.get(weekFields.weekOfMonth());
         return String.format("%d월 %d주차", month, weekOfMonth);
+    }
+
+    @Override
+    public WeeklyKeywordResponseDTO getWeeklyTopKeywords() {
+        DateRange lastWeek = getLastWeekRange();
+
+        log.info("[DEBUG] Querying keywords between startDate: {} and endDate: {}", lastWeek.start(), lastWeek.end());
+
+        // 1. DB에서 키워드별 집계 데이터 조회
+        List<QuestionKeywordRepository.KeywordCount> keywordCounts =
+            questionKeywordRepository.findKeywordCountsBetween(lastWeek.start(), lastWeek.end());
+
+        // 2. 대표 키워드(displayName) 기준으로 카운트 재집계
+        Map<String, Long> displayNameCounts = keywordCounts.stream()
+                                                           .collect(Collectors.groupingBy(
+                                                               kc -> kc.getKeyword().getDisplayName(), // 대표 이름으로 그룹핑
+                                                               Collectors.summingLong(QuestionKeywordRepository.KeywordCount::getCount) // 카운트 합산
+                                                           ));
+
+        // 3. 최종 결과를 DTO로 변환하고 순위 매기기
+        List<WeeklyKeywordResponseDTO.KeywordInfo> finalKeywords = new ArrayList<>();
+        final int[] rank = {1}; // 랭크 계산을 위한 배열
+
+        displayNameCounts.entrySet().stream()
+                         .sorted(Map.Entry.<String, Long>comparingByValue().reversed()) // 카운트 기준 내림차순 정렬
+                         .limit(3) // 상위 3개만 선택
+                         .forEach(entry -> {
+                             finalKeywords.add(
+                                 WeeklyKeywordResponseDTO.KeywordInfo.builder()
+                                                                     .rank(rank[0]++)
+                                                                     .keyword(entry.getKey())
+                                                                     .build()
+                             );
+                         });
+
+        return WeeklyKeywordResponseDTO.builder()
+                                       .keywords(finalKeywords)
+                                       .build();
     }
 }

--- a/src/main/java/com/picky/domain/home/web/controller/HomeController.java
+++ b/src/main/java/com/picky/domain/home/web/controller/HomeController.java
@@ -5,6 +5,7 @@ import com.picky.domain.ai.scheduler.AiSummaryScheduler;
 import com.picky.domain.home.service.HomeService;
 import com.picky.domain.home.web.dto.HomeResponseDTO.HotTopicResponseDTO;
 import com.picky.domain.home.web.dto.HomeResponseDTO.MostQuestionedBooksResponseDTO;
+import com.picky.domain.home.web.dto.HomeResponseDTO.WeeklyKeywordResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +42,11 @@ public class HomeController {
     @GetMapping("/most-questioned-books")
     public ApiResponse<MostQuestionedBooksResponseDTO>  getMostQuestionedBooks() {
         return ApiResponse.onSuccess(homeService.getMostQuestionedBooks());
+    }
+
+    @Operation(summary = "이번 주 키워드 TOP 3 조회 API", description = "지난주에 가장 많이 언급된 키워드 3개를 순위와 함께 조회합니다.")
+    @GetMapping("/weekly-keywords")
+    public ApiResponse<WeeklyKeywordResponseDTO> getWeeklyKeywords() {
+        return ApiResponse.onSuccess(homeService.getWeeklyTopKeywords());
     }
 }

--- a/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
+++ b/src/main/java/com/picky/domain/home/web/dto/HomeResponseDTO.java
@@ -1,5 +1,6 @@
 package com.picky.domain.home.web.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,5 +49,27 @@ public class HomeResponseDTO {
         private String bookTitle;
         private String bookAuthor;
         private String bookCover;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class WeeklyKeywordResponseDTO {
+
+        @Schema(description = "이번 주 키워드 정보 (1~3위)")
+        private List<KeywordInfo> keywords;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class KeywordInfo {
+            @Schema(description = "순위", example = "1")
+            private int rank;
+
+            @Schema(description = "키워드", example = "성장")
+            private String keyword;
+        }
     }
 }

--- a/src/main/java/com/picky/domain/question/entity/AiHashtag.java
+++ b/src/main/java/com/picky/domain/question/entity/AiHashtag.java
@@ -1,0 +1,27 @@
+package com.picky.domain.question.entity;
+
+import com.picky.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiHashtag extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id")
+    private Question question;
+
+    @Column(nullable = false)
+    private String tag; // 예: "#토론", "#서사불쌍"
+}

--- a/src/main/java/com/picky/domain/question/entity/Question.java
+++ b/src/main/java/com/picky/domain/question/entity/Question.java
@@ -54,7 +54,6 @@ public class Question extends BaseEntity {
   private Boolean isAiGenerated = false;
 
   private String aiSummary;
-  private String aiHashtags; // 해시태그는 ,로 구분된 문자열로 저장
 
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
@@ -71,8 +70,19 @@ public class Question extends BaseEntity {
   @BatchSize(size = 100)
   private List<QuestionLike> questionLikes = new ArrayList<>();
 
-  public void updateAIAnalysis(String summary, String hashtags) {
+  @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+  @Builder.Default
+  private List<AiHashtag> aiHashtags = new ArrayList<>();
+
+  @OneToMany(mappedBy = "question", cascade = CascadeType.ALL)
+    @Builder.Default
+    private List<QuestionKeyword> questionKeywords = new ArrayList<>();
+
+  public void updateAIAnalysis(String summary, List<AiHashtag> hashtags) {
     this.aiSummary = summary;
-    this.aiHashtags = hashtags;
+    this.aiHashtags.clear();
+    if (hashtags != null) {
+      this.aiHashtags.addAll(hashtags);
+    }
   }
 }

--- a/src/main/java/com/picky/domain/question/entity/QuestionKeyword.java
+++ b/src/main/java/com/picky/domain/question/entity/QuestionKeyword.java
@@ -1,0 +1,33 @@
+package com.picky.domain.question.entity;
+
+import com.picky.domain.question.entity.enums.Keyword;
+import com.picky.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionKeyword extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", foreignKey = @ForeignKey(name = "fk_questionKeyword_question"))
+    private Question question;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Keyword keyword;
+
+}

--- a/src/main/java/com/picky/domain/question/entity/enums/Keyword.java
+++ b/src/main/java/com/picky/domain/question/entity/enums/Keyword.java
@@ -1,0 +1,49 @@
+package com.picky.domain.question.entity.enums;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public enum Keyword {
+    // 인물
+    CHARACTER_PERSONALITY("성격", "성격"),
+    CHARACTER_GROWTH("성장", "성장"),
+    CHARACTER_RELATIONSHIP("관계", "관계"),
+
+    // 주제
+    SUBJECT_VALUES("가치관", "가치관"),
+    SUBJECT_SOCIETY("사회", "사회"),
+    SUBJECT_SYMBOL("상징", "상징"),
+
+    // 서사
+    STORY_STRUCTURE("구조", "구조"),
+    STORY_TECHNIQUE("기법", "기법"),
+
+    // 지식
+    KNOWLEDGE_METHOD("방법", "방법"),
+    KNOWLEDGE_APPLICATION("적용/실생활/활용", "적용"); // 대표 이름은 '적용'
+
+    private final String promptValue; // AI 프롬프트에 사용할 값
+    private final String displayName; // 프론트엔드에 보여줄 값
+
+    Keyword(String promptValue, String displayName) {
+        this.promptValue = promptValue;
+        this.displayName = displayName;
+    }
+
+    // AI 프롬프트 생성을 위한 헬퍼 메서드
+    public static String getPromptValuesAsString() {
+        return Arrays.stream(Keyword.values())
+                     .map(Keyword::getPromptValue)
+                     .collect(Collectors.joining(", "));
+    }
+
+    // AI 응답값으로 Enum을 찾기 위한 헬퍼 메서드
+    public static Keyword fromPromptValue(String promptValue) {
+        return Arrays.stream(Keyword.values())
+                     .filter(k -> k.getPromptValue().equals(promptValue))
+                     .findFirst()
+                     .orElse(null);
+    }
+}

--- a/src/main/java/com/picky/domain/question/repository/AiHashtagRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/AiHashtagRepository.java
@@ -1,0 +1,10 @@
+package com.picky.domain.question.repository;
+
+import com.picky.domain.question.entity.AiHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AiHashtagRepository extends JpaRepository<AiHashtag, Long> {
+
+}

--- a/src/main/java/com/picky/domain/question/repository/QuestionKeywordRepository.java
+++ b/src/main/java/com/picky/domain/question/repository/QuestionKeywordRepository.java
@@ -1,0 +1,30 @@
+package com.picky.domain.question.repository;
+
+import com.picky.domain.question.entity.QuestionKeyword;
+import com.picky.domain.question.entity.enums.Keyword;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionKeywordRepository extends JpaRepository<QuestionKeyword, Long> {
+
+    interface KeywordCount {
+        Keyword getKeyword();
+        Long getCount();
+    }
+
+    @Query("SELECT qk.keyword as keyword, COUNT(qk.keyword) as count " +
+        "FROM QuestionKeyword qk " +
+        "JOIN qk.question q " +
+        "WHERE q.createdAt >= :startDate AND q.createdAt < :endDate " +
+        "GROUP BY qk.keyword " +
+        "ORDER BY count DESC")
+    List<KeywordCount> findKeywordCountsBetween(
+        @Param("startDate") LocalDateTime startDate,
+        @Param("endDate") LocalDateTime endDate
+    );
+}

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -59,11 +59,11 @@ public class QuestionServiceImpl implements QuestionService {
 
         Question savedQuestion = questionRepository.save(question);
 
-        // 1. AiService를 호출해 키워드를 받아옴 (Mono를 블로킹 방식으로 처리)
-        List<String> keywords = aiService.getKeywords(savedQuestion.getTitle(), savedQuestion.getContent()).block();
-
-        // 2. 비동기로 DB에 저장
-        questionAiUpdateService.saveKeywords(savedQuestion.getId(), keywords);
+        aiService.getKeywords(savedQuestion.getTitle(), savedQuestion.getContent())
+                 // 2. 응답이 오면(비동기), 그 결과를 가지고 DB 저장 서비스를 호출
+                 .subscribe(keywords ->
+                     questionAiUpdateService.saveKeywords(savedQuestion.getId(), keywords)
+                 );
 
         return new QuestionPostResponseDTO(savedQuestion);
     }
@@ -147,14 +147,18 @@ public class QuestionServiceImpl implements QuestionService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
+        Member author = question.getMember();
+
         // 좋아요 여부 확인
         Boolean isLiked = questionLikeRepository.existsByMemberAndQuestion(member, question);
+        boolean isAuthor = author.getId().equals(memberId);
 
         return QuestionDetailResponseDTO.builder()
                 .id(question.getId())
                 .profileImg(question.getMember().getProfileImg())
                 .title(question.getTitle())
                 .content(question.getContent())
+                .authorId(author.getId())
                 .author(question.getMember().getNickname())
                 .isAI(question.getIsAiGenerated())
                 .views(question.getViews())
@@ -168,6 +172,7 @@ public class QuestionServiceImpl implements QuestionService {
                         .author(question.getBook().getAuthor())
                         .build())
                 .isLiked(isLiked)
+                .isAuthor(isAuthor)
                 .build();
     }
 

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -2,7 +2,8 @@ package com.picky.domain.question.service;
 
 import com.picky.apiPayload.code.status.ErrorStatus;
 import com.picky.apiPayload.exception.GeneralException;
-import com.picky.domain.answer.repository.AnswerRepository;
+import com.picky.domain.ai.service.AiService;
+import com.picky.domain.ai.service.QuestionAiUpdateService;
 import com.picky.domain.book.entity.Book;
 import com.picky.domain.book.repository.BookRepository;
 import com.picky.domain.member.entity.Member;
@@ -11,13 +12,13 @@ import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionDTO;
+import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionInfoResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionListResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import com.picky.domain.questionLike.repository.QuestionLikeRepository;
-import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionsResponseDTO;
-import com.picky.domain.question.web.dto.QuestionResponseDTO.MyQuestionDTO;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -30,10 +31,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class QuestionServiceImpl implements QuestionService {
 
+    private final AiService aiService;
     private final QuestionRepository questionRepository;
     private final BookRepository bookRepository;
     private final MemberRepository memberRepository;
     private final QuestionLikeRepository questionLikeRepository;
+    private final QuestionAiUpdateService questionAiUpdateService;
 
     @Override
     @Transactional
@@ -56,14 +59,13 @@ public class QuestionServiceImpl implements QuestionService {
 
         Question savedQuestion = questionRepository.save(question);
 
-        return QuestionPostResponseDTO.builder()
-                .id(savedQuestion.getId())
-                .title(savedQuestion.getTitle())
-                .content(savedQuestion.getContent())
-                .page(savedQuestion.getPageNum())
-                .isAI(savedQuestion.getIsAiGenerated())
-                .createdAt(savedQuestion.getCreatedAt())
-                .build();
+        // 1. AiService를 호출해 키워드를 받아옴 (Mono를 블로킹 방식으로 처리)
+        List<String> keywords = aiService.getKeywords(savedQuestion.getTitle(), savedQuestion.getContent()).block();
+
+        // 2. 비동기로 DB에 저장
+        questionAiUpdateService.saveKeywords(savedQuestion.getId(), keywords);
+
+        return new QuestionPostResponseDTO(savedQuestion);
     }
 
     @Override

--- a/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
+++ b/src/main/java/com/picky/domain/question/web/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package com.picky.domain.question.web.controller;
 
 import com.picky.apiPayload.ApiResponse;
+import com.picky.domain.auth.CustomerUserDetails;
 import com.picky.domain.question.service.QuestionService;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionDetailResponseDTO;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,17 +29,19 @@ public class QuestionController {
     private final QuestionService questionService;
 
     @Operation(summary = "질문 등록 API", description = "사람이 질문을 등록합니다.")
-    @PostMapping("/books/{bookId}/questions/{memberId}")
+    @PostMapping("/books/{bookId}/questions")
     public ApiResponse<QuestionPostResponseDTO> createQuestion(@PathVariable Long bookId,
-                                                               @PathVariable Long memberId,
+                                                               @AuthenticationPrincipal CustomerUserDetails customerUserDetails,
                                                                @Valid @RequestBody QuestionPostRequestDTO request) {
+        Long memberId = customerUserDetails.getMember().getId();
         return ApiResponse.onSuccess(questionService.createQuestion(bookId, memberId, request));
     }
 
     @Operation(summary = "질문 상세 조회 API", description = "질문 상세 정보를 조회합니다.")
-    @GetMapping("/questions/{questionId}/{memberId}")
+    @GetMapping("/questions/{questionId}")
     public ApiResponse<QuestionDetailResponseDTO> getQuestionDetail(@PathVariable Long questionId,
-                                                                    @PathVariable Long memberId) {
+                                                                    @AuthenticationPrincipal CustomerUserDetails customerUserDetails) {
+        Long memberId = customerUserDetails.getMember().getId();
         return ApiResponse.onSuccess(questionService.getQuestionDetail(questionId, memberId));
     }
 
@@ -48,11 +52,12 @@ public class QuestionController {
     }
 
     @Operation(summary = "질문 삭제 API", description = "특정 질문을 삭제합니다.")
-    @DeleteMapping("/questions/{questionId}/{memberId}")
+    @DeleteMapping("/questions/{questionId}")
     public ApiResponse<String> deleteQuestion(
             @PathVariable Long questionId,
-            @PathVariable Long memberId
+            @AuthenticationPrincipal CustomerUserDetails customerUserDetails
     ) {
+        Long memberId = customerUserDetails.getMember().getId();
         questionService.deleteQuestion(questionId, memberId);
         return ApiResponse.onSuccess("질문이 성공적으로 삭제되었습니다.");
     }

--- a/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
+++ b/src/main/java/com/picky/domain/question/web/dto/QuestionResponseDTO.java
@@ -41,6 +41,7 @@ public class QuestionResponseDTO {
         private String profileImg; // 작성자 프로필 이미지
         private String title;
         private String content;
+        private Long authorId;
         private String author; // 멤버 (질문 작성자)
         private Boolean isAI;
         private int views;
@@ -50,6 +51,7 @@ public class QuestionResponseDTO {
         private LocalDateTime createdAt;
         private BookInfoResponseDTO book; // 관련 책 정보
         private Boolean isLiked; // 사용자가 좋아요를 눌렀는지 여부
+        private Boolean isAuthor;
     }
 
     @Getter

--- a/src/main/java/com/picky/domain/questionLike/web/controller/QuestionLikeController.java
+++ b/src/main/java/com/picky/domain/questionLike/web/controller/QuestionLikeController.java
@@ -1,11 +1,13 @@
 package com.picky.domain.questionLike.web.controller;
 
 import com.picky.apiPayload.ApiResponse;
+import com.picky.domain.auth.CustomerUserDetails;
 import com.picky.domain.questionLike.service.QuestionLikeService;
 import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.QuestionLikeStatusResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,8 +22,9 @@ public class QuestionLikeController {
     private final QuestionLikeService questionLikeService;
 
     @Operation(summary = "질문 좋아요/취소", description = "특정 질문에 좋아요를 추가/취소합니다.")
-    @PostMapping("/{questionId}/{memberId}")
-    public ApiResponse<QuestionLikeStatusResponseDTO> likeQuestion(@PathVariable Long questionId, @PathVariable Long memberId) {
+    @PostMapping("/{questionId}")
+    public ApiResponse<QuestionLikeStatusResponseDTO> likeQuestion(@PathVariable Long questionId, @AuthenticationPrincipal CustomerUserDetails customerUserDetails) {
+        Long memberId = customerUserDetails.getMember().getId();
         return ApiResponse.onSuccess(questionLikeService.likeQuestion(questionId, memberId));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #81 

## 📝작업 내용

- 홈화면 키워드 조회 API 추가
- 질문&답변 조회 시 작성자 ID와 내가 작성한 글인지 여부 응답에 포함
- 멤버ID는 서버 내부에서 정보 가져오기
- ai 해시태그와 키워드는 각각 엔티티 따로 분리

## 💬리뷰 요구사항(선택)

- ai가 지금은 만약 질문에 해당하는 키워드가 3개가 안된다면 무시하고 2개만 생성하기도 하는데, 억지로라도 반드시 3개를 고르게 해야하나 고민