### PR TITLE
feat: 알림 기능 구현

### DIFF
--- a/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/picky/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 답변
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "ANSWER_404", "해당 답변을 찾을 수 없습니다."),
     INVALID_PARENT_ANSWER(HttpStatus.BAD_REQUEST, "ANSWER_400", "부모 답변이 유효하지 않습니다."),
-    NOT_ANSWER_AUTHOR(HttpStatus.FORBIDDEN, "ANSWER_403", "답변 작성자만 삭제할 수 있습니다.");
+    NOT_ANSWER_AUTHOR(HttpStatus.FORBIDDEN, "ANSWER_403", "답변 작성자만 삭제할 수 있습니다."),
+
+    // 알림
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_404", "해당 알림을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/picky/config/FirebaseConfig.java
+++ b/src/main/java/com/picky/config/FirebaseConfig.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.messaging.FirebaseMessaging;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -43,5 +44,10 @@ public class FirebaseConfig {
     @Bean
     public FirebaseAuth getFirebaseAuth() {
         return FirebaseAuth.getInstance(firebaseApp);
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return FirebaseMessaging.getInstance(firebaseApp);
     }
 }

--- a/src/main/java/com/picky/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/com/picky/domain/answer/repository/AnswerRepository.java
@@ -1,6 +1,7 @@
 package com.picky.domain.answer.repository;
 
 import com.picky.domain.answer.entity.Answer;
+import com.picky.domain.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
@@ -28,4 +29,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long>,
         "WHERE a.question.id = :questionId " +
         "ORDER BY a.createdAt DESC")
     List<Answer> findByQuestionIdWithMember(@Param("questionId") Long questionId);
+
+    int countByQuestion(Question question);
 }

--- a/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
+++ b/src/main/java/com/picky/domain/answer/service/AnswerServiceImpl.java
@@ -12,10 +12,15 @@ import com.picky.domain.answer.web.dto.AnswerResponseDTO.MyAnswerDTO;
 import com.picky.domain.answer.web.dto.AnswerResponseDTO.MyAnswersResponseDTO;
 import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.repository.MemberRepository;
+import com.picky.domain.notification.entity.Notification;
+import com.picky.domain.notification.entity.enums.NotificationType;
+import com.picky.domain.notification.repository.NotificationRepository;
+import com.picky.domain.notification.service.NotificationService;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -32,6 +37,8 @@ public class AnswerServiceImpl implements AnswerService {
     private final AnswerRepository answerRepository;
     private final MemberRepository memberRepository;
     private final QuestionRepository questionRepository;
+    private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
 
     @Override
     public MyAnswersResponseDTO getMyAnswers(Long memberId) {
@@ -80,7 +87,7 @@ public class AnswerServiceImpl implements AnswerService {
     @Override
     public AnswerCreateResponseDTO createAnswer(Long questionId, Long memberId, AnswerCreateRequestDTO request) {
 
-        Member member = memberRepository.findById(memberId)
+        Member answerer = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Question question = questionRepository.findById(questionId)
@@ -94,12 +101,52 @@ public class AnswerServiceImpl implements AnswerService {
             if (parentAnswer.getParentAnswer() != null) {
                 throw new GeneralException(ErrorStatus.INVALID_PARENT_ANSWER);
             }
+
+            // 대댓글 알림
+            Member parentAnswerAuthor = parentAnswer.getMember();
+            if (!parentAnswerAuthor.getId().equals(answerer.getId())) { // 본인 댓글에 대댓글 다는건 알림 X
+                String title = "Picky";
+                String body = answerer.getNickname() + "님이 회원님의 답변에 답글을 남겼습니다.";
+                Map<String, String> data = new HashMap<>();
+                data.put("type", "NEW_REPLY");
+                data.put("questionId", String.valueOf(questionId));
+                notificationService.sendNotification(title, body, answerer.getProfileImg(), parentAnswerAuthor, data);
+
+                // DB에 알림 저장
+                Notification notification = Notification.builder()
+                                                        .member(parentAnswerAuthor)
+                                                        .content(body)
+                                                        .notificationType(NotificationType.NEW_REPLY)
+                                                        .questionId(questionId)
+                                                        .parentId(parentAnswer.getId())
+                                                        .build();
+                notificationRepository.save(notification);
+            }
+        } else { // 일반 댓글 알림
+            Member questionAuthor = question.getMember();
+            if (!questionAuthor.getId().equals(answerer.getId())) { // 본인 질문에 답변 다는건 알림 X
+                String title = "Picky";
+                String body = answerer.getNickname() + "님이 회원님의 질문에 답변을 남겼습니다.";
+                Map<String, String> data = new HashMap<>();
+                data.put("type", "NEW_ANSWER");
+                data.put("questionId", String.valueOf(questionId));
+                notificationService.sendNotification(title, body, answerer.getProfileImg(), questionAuthor, data);
+
+                // DB에 알림 저장
+                Notification notification = Notification.builder()
+                                                        .member(questionAuthor)
+                                                        .content(body)
+                                                        .notificationType(NotificationType.NEW_ANSWER)
+                                                        .questionId(questionId)
+                                                        .build();
+                notificationRepository.save(notification);
+            }
         }
 
         Answer answer = Answer.builder()
                 .content(request.getContent())
                 .isAiGenerated(request.getIsAI())
-                .member(member)
+                .member(answerer)
                 .question(question)
                 .parentAnswer(parentAnswer) // 부모 답변 설정
                 .build();
@@ -109,7 +156,7 @@ public class AnswerServiceImpl implements AnswerService {
         return AnswerCreateResponseDTO.builder()
                 .id(savedAnswer.getId())
                 .content(savedAnswer.getContent())
-                .author(member.getName())
+                .author(answerer.getName())
                 .isAI(savedAnswer.getIsAiGenerated())
                 .createdAt(savedAnswer.getCreatedAt())
                 .build();

--- a/src/main/java/com/picky/domain/member/entity/Member.java
+++ b/src/main/java/com/picky/domain/member/entity/Member.java
@@ -64,4 +64,11 @@ public class Member extends BaseEntity {
   private List<QuestionLike> questionLikes = new ArrayList<>();
 
   private String profileImg;
+
+  @Column(unique = true)
+  private String fcmToken;
+
+  public void updateFcmToken(String fcmToken) {
+    this.fcmToken = fcmToken;
+  }
 }

--- a/src/main/java/com/picky/domain/member/service/MemberService.java
+++ b/src/main/java/com/picky/domain/member/service/MemberService.java
@@ -29,4 +29,12 @@ public interface MemberService {
     void validateNickname(String nickname);
 
     boolean isNicknameAvailable(String nickname);
+
+    /**
+     * FCM 토큰을 업데이트합니다.
+     *
+     * @param memberId 업데이트할 member의 id
+     * @param fcmToken 새로운 FCM 토큰
+     */
+    void updateFcmToken(Long memberId, String fcmToken);
 }

--- a/src/main/java/com/picky/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/picky/domain/member/service/MemberServiceImpl.java
@@ -86,4 +86,13 @@ public class MemberServiceImpl implements MemberService {
                 .stats(memberStatusDTO)
                 .build();
     }
+
+    @Override
+    @Transactional
+    public void updateFcmToken(Long memberId, String fcmToken) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updateFcmToken(fcmToken);
+    }
 }

--- a/src/main/java/com/picky/domain/notification/entity/Notification.java
+++ b/src/main/java/com/picky/domain/notification/entity/Notification.java
@@ -1,0 +1,50 @@
+package com.picky.domain.notification.entity;
+
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.notification.entity.enums.NotificationType;
+import com.picky.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_notification_member"))
+    private Member member; // 알림을 받은 사용자
+
+    @Column(nullable = false)
+    private String content; // 알림 내용
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @Column(nullable = false)
+    private Long questionId; // 알림 클릭 시 이동할 대상의 ID (questionId)
+
+    @Column(nullable = true)
+    private Long parentId; // 대댓글이면 부모 댓글 ID
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean isRead = false; // 읽음 여부
+
+    public void read() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/com/picky/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/picky/domain/notification/entity/enums/NotificationType.java
@@ -1,0 +1,8 @@
+package com.picky.domain.notification.entity.enums;
+
+public enum NotificationType {
+    NEW_ANSWER, // 새로운 답변
+    NEW_REPLY, // 새로운 대댓글
+    QUESTION_LIKE, // 질문 좋아요
+    VIEW_COUNT // 조회수 달성
+}

--- a/src/main/java/com/picky/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/picky/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.picky.domain.notification.repository;
+
+import com.picky.domain.notification.entity.Notification;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    Optional<Notification> findByIdAndMemberId(Long notificationId, Long memberId);
+}

--- a/src/main/java/com/picky/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/picky/domain/notification/service/NotificationService.java
@@ -1,0 +1,88 @@
+package com.picky.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.picky.apiPayload.code.status.ErrorStatus;
+import com.picky.apiPayload.exception.GeneralException;
+import com.picky.domain.member.entity.Member;
+import com.picky.domain.notification.entity.Notification;
+import com.picky.domain.notification.repository.NotificationRepository;
+import com.picky.domain.notification.web.dto.NotificationResponseDTO;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final NotificationRepository notificationRepository;
+
+    public void sendNotification(
+        String title,
+        String body,
+        String profileImg,
+        Member targetMember,
+        Map<String, String> data
+    ) {
+        // 대상 사용자의 FCM 토큰이 없는 경우 알림을 보내지 않음
+        if (targetMember.getFcmToken() == null || targetMember.getFcmToken().isEmpty()) {
+            log.warn("FCM Token is missing for member: {}", targetMember.getNickname());
+            return;
+        }
+
+        // 앱이 백그라운드일 때 표시될 알림 내용
+        com.google.firebase.messaging.Notification notification = com.google.firebase.messaging.Notification.builder()
+                                                .setTitle(title)
+                                                .setBody(body)
+                                                .setImage(profileImg)
+                                                .build();
+
+        Message message = Message.builder()
+                                 .setToken(targetMember.getFcmToken())
+                                 .setNotification(notification)
+                                 .putAllData(data) // 프론트에서 활용할 데이터
+                                 .build();
+
+        try {
+            // FCM에 메시지 전송 요청
+            firebaseMessaging.send(message);
+            log.info("Successfully sent notification to member: {}", targetMember.getNickname());
+        } catch (FirebaseMessagingException e) {
+            log.error("Failed to send notification to member: {}", targetMember.getNickname(), e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponseDTO> getNotifications(Long memberId) {
+
+        List<Notification> notifications = notificationRepository.findByMemberIdOrderByCreatedAtDesc(memberId);
+
+        return notifications.stream()
+                            .map(notification -> NotificationResponseDTO.builder()
+                                                                        .id(notification.getId())
+                                                                        .content(notification.getContent())
+                                                                        .notificationType(notification.getNotificationType())
+                                                                        .questionId(notification.getQuestionId())
+                                                                        .parentId(notification.getParentId())
+                                                                        .isRead(notification.getIsRead())
+                                                                        .createdAt(notification.getCreatedAt())
+                                                                        .build())
+                            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void readNotification(Long notificationId, Long memberId) {
+        Notification notification = notificationRepository.findByIdAndMemberId(notificationId, memberId)
+                                                        .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        notification.read();
+    }
+}

--- a/src/main/java/com/picky/domain/notification/web/controller/NotificationController.java
+++ b/src/main/java/com/picky/domain/notification/web/controller/NotificationController.java
@@ -1,0 +1,58 @@
+package com.picky.domain.notification.web.controller;
+
+import com.picky.apiPayload.ApiResponse;
+import com.picky.domain.auth.CustomerUserDetails;
+import com.picky.domain.member.service.MemberService;
+import com.picky.domain.notification.service.NotificationService;
+import com.picky.domain.notification.web.dto.FcmTokenRequestDTO;
+import com.picky.domain.notification.web.dto.NotificationResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+@Tag(name = "알림")
+public class NotificationController {
+
+    private final MemberService memberService;
+    private final NotificationService notificationService;
+
+    @Operation(summary = "FCM 토큰 저장 API", description = "사용자의 FCM 토큰을 저장합니다.")
+    @PostMapping("/fcm-token")
+    public ApiResponse<Void> updateFcmToken(@AuthenticationPrincipal CustomerUserDetails customerUserDetails,
+                                            @Valid @RequestBody FcmTokenRequestDTO request) {
+        Long memberId = customerUserDetails.getMember().getId();
+        String fcmToken = request.getFcmToken();
+        memberService.updateFcmToken(memberId, fcmToken);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "알림 목록 조회", description = "사용자의 알림 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponse<List<NotificationResponseDTO>> getNotifications(@AuthenticationPrincipal CustomerUserDetails customerUserDetails) {
+        Long memberId = customerUserDetails.getMember().getId();
+        List<NotificationResponseDTO> notifications = notificationService.getNotifications(memberId);
+        return ApiResponse.onSuccess(notifications);
+    }
+
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 처리합니다.")
+    @PatchMapping("/{notificationId}/read")
+    public ApiResponse<Void> readNotification(@AuthenticationPrincipal CustomerUserDetails customerUserDetails,
+                                        @PathVariable Long notificationId) {
+        Long memberId = customerUserDetails.getMember().getId();
+        notificationService.readNotification(notificationId, memberId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/picky/domain/notification/web/dto/FcmTokenRequestDTO.java
+++ b/src/main/java/com/picky/domain/notification/web/dto/FcmTokenRequestDTO.java
@@ -1,0 +1,13 @@
+package com.picky.domain.notification.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmTokenRequestDTO {
+
+    @Schema(description = "알림을 받을 사람의 토큰")
+    private String fcmToken;
+}

--- a/src/main/java/com/picky/domain/notification/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/com/picky/domain/notification/web/dto/NotificationResponseDTO.java
@@ -1,0 +1,33 @@
+package com.picky.domain.notification.web.dto;
+
+import com.picky.domain.notification.entity.enums.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationResponseDTO {
+
+    private Long id;
+    private String content;
+
+    @Schema(description = "알림 타입 (NEW_ANSWER, NEW_REPLY, QUESTION_LIKE, VIEW_COUNT)")
+    private NotificationType notificationType;
+
+    @Schema(description = "알림 클릭 시 이동할 대상 ID (예: questionId)")
+    private Long questionId; // 알림과 관련된 대상 ID (예: 질문 ID)
+
+    @Schema(description = "대댓글 알림의 경우, 부모 댓글의 ID")
+    private Long parentId;
+
+    @Schema(description = "알림 읽음 여부")
+    private Boolean isRead;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
+++ b/src/main/java/com/picky/domain/question/service/QuestionServiceImpl.java
@@ -4,10 +4,15 @@ import com.picky.apiPayload.code.status.ErrorStatus;
 import com.picky.apiPayload.exception.GeneralException;
 import com.picky.domain.ai.service.AiService;
 import com.picky.domain.ai.service.QuestionAiUpdateService;
+import com.picky.domain.answer.repository.AnswerRepository;
 import com.picky.domain.book.entity.Book;
 import com.picky.domain.book.repository.BookRepository;
 import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.repository.MemberRepository;
+import com.picky.domain.notification.entity.Notification;
+import com.picky.domain.notification.entity.enums.NotificationType;
+import com.picky.domain.notification.repository.NotificationRepository;
+import com.picky.domain.notification.service.NotificationService;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.question.web.dto.QuestionRequestDTO.QuestionPostRequestDTO;
@@ -19,6 +24,7 @@ import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionInfoRespons
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionListResponseDTO;
 import com.picky.domain.question.web.dto.QuestionResponseDTO.QuestionPostResponseDTO;
 import com.picky.domain.questionLike.repository.QuestionLikeRepository;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -37,6 +43,9 @@ public class QuestionServiceImpl implements QuestionService {
     private final MemberRepository memberRepository;
     private final QuestionLikeRepository questionLikeRepository;
     private final QuestionAiUpdateService questionAiUpdateService;
+    private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
+    private final AnswerRepository answerRepository;
 
     @Override
     @Transactional
@@ -135,14 +144,36 @@ public class QuestionServiceImpl implements QuestionService {
     @Transactional // 조회수 증가 메서드 때문에 붙임
     public QuestionDetailResponseDTO getQuestionDetail(Long questionId, Long memberId) {
 
-        // 조회수 증가
-        int updatedViews = questionRepository.increaseViews(questionId);
-        if (updatedViews == 0) {
-            throw new GeneralException(ErrorStatus.QUESTION_NOT_FOUND);
-        }
-
         Question question = questionRepository.findByIdWithBookAndMember(questionId)
                                               .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
+
+        // 조회수 15 달성 알림 로직
+        // 현재 조회수가 14일 때만 실행 (이번 조회로 15가 되므로)
+        if (question.getViews() == 14) {
+            Member questionAuthor = question.getMember();
+
+            // 본인이 본인 글을 봐서 15가 되는 경우는 알림 X
+            if (!questionAuthor.getId().equals(memberId)) {
+                String title = "Picky";
+                String body = "회원님이 작성한 게시글이 주목받고 있어요!";
+                Map<String, String> data = new HashMap<>();
+                data.put("type", "VIEW_COUNT_ACHIEVED");
+                data.put("questionId", String.valueOf(questionId));
+                notificationService.sendNotification(title, body, null, questionAuthor, data);
+
+                // DB에 알림 저장
+                Notification notification = Notification.builder()
+                                                        .member(questionAuthor)
+                                                        .content(body)
+                                                        .notificationType(NotificationType.VIEW_COUNT)
+                                                        .questionId(questionId)
+                                                        .build();
+                notificationRepository.save(notification);
+            }
+        }
+
+        // 조회수 증가
+        questionRepository.increaseViews(questionId);
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -153,17 +184,20 @@ public class QuestionServiceImpl implements QuestionService {
         Boolean isLiked = questionLikeRepository.existsByMemberAndQuestion(member, question);
         boolean isAuthor = author.getId().equals(memberId);
 
+        int likeCounts = questionLikeRepository.countByQuestion(question);
+        int answerCounts = answerRepository.countByQuestion(question);
+
         return QuestionDetailResponseDTO.builder()
                 .id(question.getId())
-                .profileImg(question.getMember().getProfileImg())
+                .profileImg(author.getProfileImg())
                 .title(question.getTitle())
                 .content(question.getContent())
                 .authorId(author.getId())
-                .author(question.getMember().getNickname())
+                .author(author.getNickname())
                 .isAI(question.getIsAiGenerated())
-                .views(question.getViews())
-                .likes(question.getQuestionLikes().size())
-                .answersCount(question.getAnswers().size())
+                .views(question.getViews() + 1)
+                .likes(likeCounts)
+                .answersCount(answerCounts)
                 .page(question.getPageNum())
                 .createdAt(question.getCreatedAt())
                 .book(QuestionResponseDTO.BookInfoResponseDTO.builder()

--- a/src/main/java/com/picky/domain/questionLike/service/QuestionLikeServiceImpl.java
+++ b/src/main/java/com/picky/domain/questionLike/service/QuestionLikeServiceImpl.java
@@ -4,6 +4,10 @@ import com.picky.apiPayload.code.status.ErrorStatus;
 import com.picky.apiPayload.exception.GeneralException;
 import com.picky.domain.member.entity.Member;
 import com.picky.domain.member.repository.MemberRepository;
+import com.picky.domain.notification.entity.Notification;
+import com.picky.domain.notification.entity.enums.NotificationType;
+import com.picky.domain.notification.repository.NotificationRepository;
+import com.picky.domain.notification.service.NotificationService;
 import com.picky.domain.question.entity.Question;
 import com.picky.domain.question.repository.QuestionRepository;
 import com.picky.domain.questionLike.entity.QuestionLike;
@@ -12,6 +16,7 @@ import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.QuestionLik
 import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.MyLikesResponseDTO;
 import com.picky.domain.questionLike.web.dto.QuestionLikeResponseDTO.LikeItemDTO;
 import com.picky.global.util.TimeUtils;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +33,8 @@ public class QuestionLikeServiceImpl implements QuestionLikeService{
     private final QuestionRepository questionRepository;
     private final MemberRepository memberRepository;
     private final QuestionLikeRepository questionLikeRepository;
+    private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
 
     @Override
     public QuestionLikeStatusResponseDTO likeQuestion(Long questionId, Long memberId) {
@@ -35,11 +42,11 @@ public class QuestionLikeServiceImpl implements QuestionLikeService{
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.QUESTION_NOT_FOUND));
 
-        Member member = memberRepository.findById(memberId)
+        Member liker = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
 
-        Optional<QuestionLike> existingLike = questionLikeRepository.findByMemberAndQuestion(member, question);
+        Optional<QuestionLike> existingLike = questionLikeRepository.findByMemberAndQuestion(liker, question);
 
         if(existingLike.isPresent()) {
             // 이미 좋아요 했으면 취소 처리
@@ -55,9 +62,29 @@ public class QuestionLikeServiceImpl implements QuestionLikeService{
             // 좋아요 안했으면 추가 처리
             QuestionLike questionLike = QuestionLike.builder()
                     .question(question)
-                    .member(member)
+                    .member(liker)
                     .build();
             questionLikeRepository.save(questionLike);
+
+            // 알림
+            Member questionAuthor = question.getMember();
+            if (!questionAuthor.getId().equals(liker.getId())) { // 본인 글에 좋아요 누르는건 알림 X
+                String title = "Picky";
+                String body = liker.getNickname() + "님이 회원님의 질문에 좋아요를 눌렀습니다.";
+                Map<String, String> data = new HashMap<>();
+                data.put("type", "QUESTION_LIKE");
+                data.put("questionId", String.valueOf(questionId));
+                notificationService.sendNotification(title, body, liker.getProfileImg(), questionAuthor, data);
+
+                // DB에 알림 저장
+                Notification notification = Notification.builder()
+                                                        .member(questionAuthor)
+                                                        .content(body)
+                                                        .notificationType(NotificationType.QUESTION_LIKE)
+                                                        .questionId(questionId)
+                                                        .build();
+                notificationRepository.save(notification);
+            }
 
             int likeCounts = questionLikeRepository.countByQuestion(question);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- Closes #111 

## 📝작업 내용

아래 내용에 대해 알림 가도록 하고 DB에 알림 내용과 타입이 저장되도록 해서 알림 목록 조회 API에서 응답으로 주고, 알림 읽음 여부 같이 주고 있어요

- 내가 작성한 질문에 누군가 답변(댓글)을 남겼을 때 / 내가 작성한 댓글에 누군가 대댓글을 남겼을 때 / 내가 작성한 질문에 누군가 좋아요를 눌렀을 때 / 내가 작성한 질문이 조회수가 15개가 되었을 때

그리고 누르면 모든 경우에 다 어차피 해당 질문 게시글로 이동해야 할 것 같아서 questionId 응답으로 보내주고, 만약 답변에 대댓글이 달린 경우라면 답변으로도 이동해야 하니까 parentId 같이 줍니다. 나머지 경우엔 parentId는 null이에요